### PR TITLE
Remove explicit stage instance

### DIFF
--- a/cosmicds/registries.py
+++ b/cosmicds/registries.py
@@ -67,8 +67,7 @@ class StoryRegistry(UniqueDictRegistry):
                                      "step_index": 0,
                                      "steps": [{'title': x, 'completed': False} 
                                                for x in v['steps']],
-                                     "model_id": f"IPY_MODEL_{stage.model_id}",
-                                     "_instance": stage}
+                                     "model_id": f"IPY_MODEL_{stage.model_id}"}
 
         return story_state
 


### PR DESCRIPTION
I had asked @nmearl to put in explicit references to each stage for debugging purposes, but it turns out they aren't JSON serializable, and so the application won't run with that present. I removed this in my local version but forgot to add it to #84, so let's do it here.