### PR TITLE
Fix issue with updating using_voila property

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -185,7 +185,7 @@ export default {
       .call(document.getElementsByTagName('script'))
       .map(e => e.src)
       .find(e => e.includes('voila/static'));
-    this.using_voila = item !== undefined;
+    this.app_state.using_voila = item !== undefined;
 
     if (this.$data.story_state.use_mathjax) {
       window.MathJax = {

--- a/cosmicds/stories/hubbles_law/stages/stage_intro.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_intro.py
@@ -34,9 +34,7 @@ class StageIntro(Stage):
         intro_slideshow = IntroSlideshow(self.stage_state)
         self.add_component(intro_slideshow, label='c-intro-slideshow')
         intro_slideshow.observe(self._on_slideshow_complete, names=['intro_complete'])
-
         self.stage_state.image_location = "data/images"
-        add_callback(self.app_state, 'using_voila', self._update_image_location)
 
     @property
     def slideshow(self):
@@ -49,7 +47,3 @@ class StageIntro(Stage):
             # We need to do this so that the stage will be moved forward every
             # time the button is clicked, not just the first
             self.slideshow.intro_complete = False
-
-    def _update_image_location(self, using_voila):
-        prepend = "voila/files/" if using_voila else ""
-        self.stage_state.image_location = prepend + "data/images"


### PR DESCRIPTION
This PR fixes a bug in `app.vue`, where the update to `using_voila` is incorrectly applied to a member value of the application, rather than the application state.

In fixing this, I also realized that we don't actually need the update to the image location via the `using_voila` variable - voila will automatically redirect to the correct file by prepending `voila/files`. I think our only issue before was voila struggling to handle the `..`-based upwards navigation. Thus, I've removed that bit of code here. However, I still think it's potentially useful for the application to know whether voila is running or not.