### PR TITLE
style spectrum viewer - works only in dark mode so far

### DIFF
--- a/cosmicds/stories/hubbles_law/data/styles/default_spectrum_dark.json
+++ b/cosmicds/stories/hubbles_law/data/styles/default_spectrum_dark.json
@@ -1,0 +1,51 @@
+{
+  "figure": {
+    "background_style": {
+      "fill": "#fffef5"
+    },
+    "fig_margin": {
+      "left": 100,
+      "bottom": 60,
+      "top": 10,
+      "right": 10
+    },
+    "axes": [
+      {
+        "tick_format": ",.0f",
+        "tick_style": {
+          "font-size": "1.5em",
+          "color": "White"
+        },
+        "label_offset": "3em",
+        "label": "Wavelength (Angstrom)",
+        "color": "White",
+        "label_color": "White",
+        "grid_color": "White"
+      },
+      {
+        "tick_format": ",.0f",
+        "tick_style": {
+          "font-size": "1.5em",
+          "color": "White"
+        },
+        "label_offset": "3.5em",
+        "label": "Brightness",
+        "color": "White",
+        "label_color": "White",
+        "grid_color": "White"
+      }
+    ]
+  },
+  "viewer": {
+    "scatter": {
+      "marker": "circle",
+      "stroke_width": 0,
+      "enable_hover": true
+    },
+    "state": {
+      "size": 3,
+      "color": "gray"
+    }
+  }
+}
+

--- a/cosmicds/stories/hubbles_law/stages/stage_one.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.py
@@ -8,7 +8,7 @@ from random import sample
 from traitlets import default
 
 from cosmicds.registries import register_stage
-from cosmicds.utils import load_template
+from cosmicds.utils import load_template, update_figure_css
 from cosmicds.stories.hubbles_law.viewers import SpectrumView
 from cosmicds.phases import Stage
 from cosmicds.components.table import Table
@@ -79,6 +79,12 @@ class StageOne(Stage):
         # Set up viewers
         spectrum_viewer = self.add_viewer(SpectrumView, label="spectrum_viewer")
         spectrum_viewer.add_event_callback(self.on_spectrum_click, events=['click'])
+
+        # Set up viewer style   
+        style_dir = Path(__file__).parent.parent / "data" / "styles"
+        self.spectrum_style_path = style_dir / "default_spectrum_dark.json"
+
+        update_figure_css(spectrum_viewer, style_path=self.spectrum_style_path)
 
         for label in ['hub_const_viewer', 'hub_fit_viewer',
                       'hub_comparison_viewer', 'hub_students_viewer',
@@ -192,6 +198,8 @@ class StageOne(Stage):
             spec_data = self.get_data("spectrum_data")
             specview.add_data(spec_data)
         specview.state.reset_limits()
+        update_figure_css(specview, style_path=self.spectrum_style_path)
+        
         self.stage_state.waveline_set = False
 
         sdss = self.get_data("SDSS_all_sample_filtered")


### PR DESCRIPTION
Bring over functionality from old-main PR85 to new main and will close #85.

Keeping in draft mode for now while we iron out these issues:
- For now, this makes all the plot labels white, so they will disappear in light mode. We need to figure out how to trigger style updates for all the viewers when the darkmode is toggled.
- The y-axis tick marker numbers are wonky. They are fine on the first galaxy, but when you switch to other galaxies with different y-axis values, only the numbers that were on the original galaxy plot appear.
