### PR TITLE
Fix WWT 404 error in notebook

### DIFF
--- a/cosmicds/stories/hubbles_law/components/exploration_tool/exploration_tool.vue
+++ b/cosmicds/stories/hubbles_law/components/exploration_tool/exploration_tool.vue
@@ -1,5 +1,13 @@
 <template>
-  <v-card outlined color="info" class="pa-1">
+  <v-card outlined color="info" class="pa-1"
+    v-intersect.once="(entries, observer, isIntersecting) => {
+      const root = entries[0].target;
+      const element = root.querySelector('iframe');
+      if (element) {
+        element.src = element.src.replace('/api/kernels', '');
+      }
+    }"
+  >
     <v-toolbar color="secondary" height="40px" dense dark class="text-uppercase">
       <v-toolbar-title>Night Sky Viewer</v-toolbar-title>
       <v-spacer></v-spacer>          

--- a/cosmicds/stories/hubbles_law/components/selection_tool/selection_tool.vue
+++ b/cosmicds/stories/hubbles_law/components/selection_tool/selection_tool.vue
@@ -1,6 +1,13 @@
 <template>
   <div
     id="selection-root"
+    v-intersect.once="(entries, observer, isIntersecting) => {
+      const root = entries[0].target;
+      const element = root.querySelector('iframe');
+      if (element) {
+        element.src = element.src.replace('/api/kernels', '');
+      }
+    }"
   >
     <v-toolbar
       color="secondary"


### PR DESCRIPTION
This PR fixes the 404 error in the WWT widgets when running the app inside a Jupyter notebook. This is done via an intersection observer that manually adjusts the `iframe` source the first time it's triggered. This is pretty hacky, but since we only need the notebook for our testing I think it's more than adequate.