### PR TITLE
Student data generation

### DIFF
--- a/cosmicds/__init__.py
+++ b/cosmicds/__init__.py
@@ -17,11 +17,3 @@ for comp_path in vue_comp_dir.iterdir():
 
 from .stories import *
 from .tools import *
-
-# Monkey-patch pywwt kernel connection function
-from pywwt import jupyter_relay
-
-def _override_compute_notebook_server_base_url():
-    return "/api/kernels/"
-
-jupyter_relay._compute_notebook_server_base_url = _override_compute_notebook_server_base_url

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -41,7 +41,8 @@ class Application(VuetifyTemplate, HubListener):
         
         # For testing purposes, we create a new dummy student on each startup
         if self.app_state.update_db:
-            response = requests.get(f"{API_URL}/new-dummy-student").json()
+            data = { "seed": True, "team_member": kwargs.get("team_member", None) }
+            response = requests.post(f"{API_URL}/new-dummy-student", json=data).json()
             self.app_state.student = response["student"]
 
         self._application_handler = JupyterApplication()

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -1,7 +1,7 @@
 import ipyvuetify as v
 import requests
 import json
-from echo import add_callback, CallbackProperty
+from echo import add_callback, ignore_callback, CallbackProperty
 from glue.core.state_objects import State
 from glue_jupyter.app import JupyterApplication
 from glue_jupyter.state_traitlets_helpers import GlueState
@@ -120,3 +120,5 @@ class Application(VuetifyTemplate, HubListener):
             data = { "seed": True, "team_member": self.team_member }
             response = requests.post(f"{API_URL}/new-dummy-student", json=data).json()
             self.app_state.student = response["student"]
+            with ignore_callback(self.app_state, 'reset_student'):
+                self.app_state.reset_student = False

--- a/cosmicds/components/table/table.py
+++ b/cosmicds/components/table/table.py
@@ -207,4 +207,7 @@ class Table(VuetifyTemplate, HubListener):
             self.selected = self.selected + [item]
 
     def vue_update_sort_by(self, field, _args=None):
-        self.sort_by = field
+        # We get a list of the form ['sort_field']
+        # which is empty is there isn't a sort field selected
+        # We default to the key component
+        self.sort_by = field[0] if len(field) > 0 else self.key_component

--- a/cosmicds/components/table/table.py
+++ b/cosmicds/components/table/table.py
@@ -181,7 +181,7 @@ class Table(VuetifyTemplate, HubListener):
 
     @property
     def index(self):
-        if self.single_select:
+        if self.single_select and len(self.indices) > 0:
             return self.indices[0]
         return None
 

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -138,6 +138,15 @@ class Stage(TemplateMixin):
         values[index] = value
         data.update_components({data.id[comp_name] : values})
 
+    def update_data_values(self, dc_name, values, index):
+        data = self.data_collection[dc_name]
+        comp_dict = {}
+        for comp, value in values.items():
+            vals = data[comp]
+            vals[index] = value
+            comp_dict[data.id[comp]] = vals
+        data.update_components(comp_dict)
+
     def add_data_values(self, dc_name, values):
         data = self.data_collection[dc_name]
         main_components = [x.label for x in data.main_components]

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -13,7 +13,7 @@ from echo import DictCallbackProperty, CallbackProperty, add_callback
 
 class Story(State, HubMixin):
     name = CallbackProperty()
-    stage_index = CallbackProperty(0)
+    stage_index = CallbackProperty(1) #temporarily skip intro
     step_index = CallbackProperty(0)
     step_complete = CallbackProperty(False)
     stages = DictCallbackProperty()

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -9,6 +9,7 @@ from cosmicds.utils import load_template
 from glue.core import Data
 from glue.core.state_objects import State
 from echo import DictCallbackProperty, CallbackProperty, add_callback
+from numpy import delete
 
 
 class Story(State, HubMixin):
@@ -147,10 +148,25 @@ class Stage(TemplateMixin):
         self.story_state.make_data_writeable(new_data)
         data.update_values_from_data(new_data)
 
-    def get_data_index(self, dc_name, component, condition):
+    def get_data_indices(self, dc_name, component, condition, single=False):
         data = self.data_collection[dc_name]
         component = data[component]
-        return next((index for index, x in enumerate(component) if condition(x)), None)
+        if single:
+            return next((index for index, x in enumerate(component) if condition(x)), None)
+        else:
+            return list(index for index, x in enumerate(component) if condition(x))
+
+    def remove_data_values(self, dc_name, component, condition, single=False):
+        indices = self.get_data_indices(dc_name, component, condition, single=single)
+        if single:
+            indices = [indices]
+        data = self.get_data(dc_name)
+        component = data[component]
+        main_components = [x.label for x in data.main_components]
+        component_dict = {c : delete(data[c], indices) for c in main_components}
+        new_data = Data(label=data.label, **component_dict)
+        self.story_state.make_data_writeable(new_data)
+        data.update_values_from_data(new_data)
 
     def vue_set_step_index(self, value):
         self.story_state.step_index = value

--- a/cosmicds/stories/hubbles_law/CosmicDS.ipynb
+++ b/cosmicds/stories/hubbles_law/CosmicDS.ipynb
@@ -2,14 +2,32 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b2b64746865140bfb8892408165e61b1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Application(app_state=<ApplicationState\n",
+       "  dark_mode: True\n",
+       "  reset_student: False\n",
+       "  student: {'profile_created'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from warnings import filterwarnings\n",
     "\n",
@@ -17,7 +35,7 @@
     "\n",
     "from cosmicds.app import Application\n",
     "\n",
-    "app = Application(story='hubbles_law')\n",
+    "app = Application(story='hubbles_law', team_member='pat')\n",
     "app"
    ]
   },

--- a/cosmicds/stories/hubbles_law/components/distance_sidebar/distance_sidebar.py
+++ b/cosmicds/stories/hubbles_law/components/distance_sidebar/distance_sidebar.py
@@ -18,7 +18,7 @@ class DistanceSidebar(v.VuetifyTemplate):
     def __init__(self, state, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.state = state
-        add_callback(self.state, 'selected_galaxy', self._on_galaxy_update)
+        add_callback(self.state, 'galaxy', self._on_galaxy_update)
 
     def _on_galaxy_update(self, galaxy):
         self.galaxy_type = galaxy["type"]

--- a/cosmicds/stories/hubbles_law/components/distance_sidebar/distance_sidebar.vue
+++ b/cosmicds/stories/hubbles_law/components/distance_sidebar/distance_sidebar.vue
@@ -1,9 +1,10 @@
 <template>
   <v-card
     width="100%"
+    color="primary"
   >
     <v-card-title>{{state.galaxy.name || ""}}</v-card-title>
-    <v-card-text>
+    <v-card-text color="primary">
       <v-divider></v-divider>
       <v-list>
         <v-list-item-content>

--- a/cosmicds/stories/hubbles_law/components/distance_sidebar/distance_sidebar.vue
+++ b/cosmicds/stories/hubbles_law/components/distance_sidebar/distance_sidebar.vue
@@ -2,13 +2,13 @@
   <v-card
     width="100%"
   >
-    <v-card-title>{{state.distance_name || "Galaxy Name"}}</v-card-title>
+    <v-card-title>{{state.galaxy.name || ""}}</v-card-title>
     <v-card-text>
       <v-divider></v-divider>
       <v-list>
         <v-list-item-content>
-          <v-list-item-title>{{state.distance_type || "Galaxy Type"}}</v-list-item-title>
-          <v-list-item-subtitle>type</v-list-item-subtitle>
+          <v-list-item-title>{{state.galaxy.type || "--"}}</v-list-item-title>
+          <v-list-item-subtitle>galaxy type</v-list-item-subtitle>
         </v-list-item-content>
         <v-list-item-content>
           <v-list-item-title>100,000 light years</v-list-item-title>
@@ -19,33 +19,10 @@
           <v-list-item-subtitle>field of view</v-list-item-subtitle>
         </v-list-item-content>
         <v-list-item-content>
-          <v-list-item-title>{{angular_size}}</v-list-item-title>
+          <v-list-item-title>{{angular_size || "--"}}</v-list-item-title>
           <v-list-item-subtitle>measured angular size</v-list-item-subtitle>
         </v-list-item-content>
       </v-list>
-      <v-divider></v-divider>
-      <v-text-field
-        :value="state.galaxy_dist"
-        label="Estimated Distance"
-        hint="click button below"
-        persistent-hint
-        class="mt-8 mb-4"
-        suffix="Mpc"
-        outlined
-        readonly
-        dense
-      ></v-text-field>
-      <v-btn
-        block
-        color="primary"
-        dark
-        class="px-auto"
-        max-width="100%"
-        :disabled="!state.measure_gal_selected || state.measured_ang_size === 0 || state.distance_view_changing"
-        @click="add_distance_data_point()"
-      >
-        estimate
-      </v-btn>
     </v-card-text>
   </v-card>
 </template>

--- a/cosmicds/stories/hubbles_law/components/distance_tool/distance_tool.py
+++ b/cosmicds/stories/hubbles_law/components/distance_tool/distance_tool.py
@@ -1,10 +1,12 @@
+import requests
+
 import ipyvue as v
 from astropy.coordinates import Angle, SkyCoord
 import astropy.units as u
-from cosmicds.utils import RepeatedTimer, load_template
+from cosmicds.utils import RepeatedTimer, load_template, API_URL
 from cosmicds.stories.hubbles_law.utils import GALAXY_FOV, angle_to_json, angle_from_json
 from pywwt.jupyter import WWTJupyterWidget
-from traitlets import Instance, Bool, Float, Int, observe
+from traitlets import Instance, Bool, Dict, Float, Int, observe
 from ipywidgets import DOMWidget, widget_serialization
 from datetime import datetime
 
@@ -19,6 +21,7 @@ class DistanceTool(v.VueTemplate):
     width = Int().tag(sync=True)
     view_changing = Bool(False).tag(sync=True)
     measuring_allowed = Bool(False).tag(sync=True)
+    galaxy = Dict().tag(sync=True)
     _ra = Angle(0 * u.deg)
     _dec = Angle(0 * u.deg)
 
@@ -85,3 +88,7 @@ class DistanceTool(v.VueTemplate):
     def go_to_location(self, ra, dec, fov=GALAXY_FOV):
         coordinates = SkyCoord(ra * u.deg, dec * u.deg, frame='icrs')
         self.widget.center_on_coordinates(coordinates, fov=fov, instant=True)
+
+    def vue_mark_galaxy_bad(self, _args=None):
+        data = { "galaxy_id" : int(self.galaxy["id"]) }
+        requests.put(f"{API_URL}/mark-galaxy-bad", json=data)

--- a/cosmicds/stories/hubbles_law/components/distance_tool/distance_tool.py
+++ b/cosmicds/stories/hubbles_law/components/distance_tool/distance_tool.py
@@ -4,6 +4,7 @@ import ipyvue as v
 from astropy.coordinates import Angle, SkyCoord
 import astropy.units as u
 from cosmicds.utils import RepeatedTimer, load_template, API_URL
+from cosmicds.stories.hubbles_law.utils import HUBBLE_ROUTE_PATH
 from cosmicds.stories.hubbles_law.utils import GALAXY_FOV, angle_to_json, angle_from_json
 from pywwt.jupyter import WWTJupyterWidget
 from traitlets import Instance, Bool, Dict, Float, Int, observe
@@ -22,6 +23,8 @@ class DistanceTool(v.VueTemplate):
     view_changing = Bool(False).tag(sync=True)
     measuring_allowed = Bool(False).tag(sync=True)
     galaxy = Dict().tag(sync=True)
+    flagged = Bool(False).tag(sync=True)
+
     _ra = Angle(0 * u.deg)
     _dec = Angle(0 * u.deg)
 
@@ -89,6 +92,7 @@ class DistanceTool(v.VueTemplate):
         coordinates = SkyCoord(ra * u.deg, dec * u.deg, frame='icrs')
         self.widget.center_on_coordinates(coordinates, fov=fov, instant=True)
 
-    def vue_mark_galaxy_bad(self, _args=None):
+    @observe('flagged')
+    def mark_galaxy_bad(self, _args=None):
         data = { "galaxy_id" : int(self.galaxy["id"]) }
-        requests.put(f"{API_URL}/mark-galaxy-bad", json=data)
+        requests.put(f"{API_URL}/{HUBBLE_ROUTE_PATH}/mark-galaxy-bad", json=data)

--- a/cosmicds/stories/hubbles_law/components/distance_tool/distance_tool.vue
+++ b/cosmicds/stories/hubbles_law/components/distance_tool/distance_tool.vue
@@ -1,5 +1,22 @@
 <template>
-  <div id="distance-root">
+  <div
+    id="distance-root"
+    v-intersect="(entries, observer, isIntersecting) => {
+      /**
+        We can't just use .once
+        since that seems to run before the viewer actually comes into view
+        so we'll just manually keep track of whether the iframe
+        has been updated or not
+      */
+      if (this.ranIntersectObserver) { return; }
+      const root = entries[0].target;
+      const element = root.querySelector('iframe');
+      if (element) {
+        element.src = element.src.replace('/api/kernels', '');
+        this.ranIntersectObserver = true;
+      }
+    }"
+  >
     <v-toolbar
       color="primary"
       dense
@@ -48,6 +65,7 @@ export default {
   mounted() {
     this.setup();
     this.reset();
+    this.ranIntersectObserver = false;
     window.addEventListener('resize', this.handleResize);
     // We don't get a Window resize event when the canvas first appears
     // so we watch the canvas' dimensions instead

--- a/cosmicds/stories/hubbles_law/components/distance_tool/distance_tool.vue
+++ b/cosmicds/stories/hubbles_law/components/distance_tool/distance_tool.vue
@@ -39,6 +39,20 @@
         {{ measuring ? 'Stop measuring' : 'Start measuring'}}
       </v-tooltip>
 
+      <v-tooltip top>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn icon
+            v-bind="attrs"
+            v-on="on"
+            :disabled="Object.keys(galaxy).length == 0"
+            @click="mark_galaxy_bad()"
+          >
+            <v-icon>mdi-flag</v-icon>
+          </v-btn>
+        </template>
+        Flag galaxy as missing image
+      </v-tooltip>
+
       <v-btn icon>
         <v-icon>mdi-information-outline</v-icon>
       </v-btn>

--- a/cosmicds/stories/hubbles_law/components/distance_tool/distance_tool.vue
+++ b/cosmicds/stories/hubbles_law/components/distance_tool/distance_tool.vue
@@ -45,7 +45,7 @@
             v-bind="attrs"
             v-on="on"
             :disabled="Object.keys(galaxy).length == 0"
-            @click="mark_galaxy_bad()"
+            @click="flagged = true"
           >
             <v-icon>mdi-flag</v-icon>
           </v-btn>

--- a/cosmicds/stories/hubbles_law/stage.py
+++ b/cosmicds/stories/hubbles_law/stage.py
@@ -3,6 +3,7 @@ import requests
 
 from cosmicds.phases import Stage
 from cosmicds.utils import API_URL, CDSJSONEncoder
+from cosmicds.stories.hubbles_law.utils import HUBBLE_ROUTE_PATH
 
 class HubbleStage(Stage):
 
@@ -37,7 +38,7 @@ class HubbleStage(Stage):
 
     def submit_measurement(self, measurement):
         prepared = self._prepare_measurement(measurement)
-        requests.put(f"{API_URL}/submit-measurement", json=prepared)
+        requests.put(f"{API_URL}/{HUBBLE_ROUTE_PATH}/submit-measurement", json=prepared)
 
     def update_data_value(self, dc_name, comp_name, value, index):
         super().update_data_value(dc_name, comp_name, value, index)

--- a/cosmicds/stories/hubbles_law/stage.py
+++ b/cosmicds/stories/hubbles_law/stage.py
@@ -40,6 +40,11 @@ class HubbleStage(Stage):
         prepared = self._prepare_measurement(measurement)
         requests.put(f"{API_URL}/{HUBBLE_ROUTE_PATH}/submit-measurement", json=prepared)
 
+    def remove_measurement(self, galaxy_name):
+        user = self.app_state.student
+        if user.get("id", None) is not None:
+            requests.delete(f"{API_URL}/{HUBBLE_ROUTE_PATH}/measurement/{user['id']}/{galaxy_name}")
+
     def update_data_value(self, dc_name, comp_name, value, index):
         super().update_data_value(dc_name, comp_name, value, index)
 

--- a/cosmicds/stories/hubbles_law/stages/stage_one.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.py
@@ -185,6 +185,11 @@ class StageOne(HubbleStage):
         add_callback(self.story_state, 'step_index', self._on_step_index_update)
         self.trigger_marker_update_cb = True
 
+        def reset(flag):
+            if flag:
+                self.marker = self.markers[0]
+        add_callback(self.story_state, 'reset_flag', reset)
+
     def _on_marker_update(self, old, new):
         if not self.trigger_marker_update_cb:
             return

--- a/cosmicds/stories/hubbles_law/stages/stage_one.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.py
@@ -37,9 +37,9 @@ class StageState(State):
     doppler_calc_complete = CallbackProperty(False)
 
     markers = CallbackProperty([
-        'mee_gui1',
-        'sel_gal1',
-        'sel_gal2',
+        # 'mee_gui1',
+        # 'sel_gal1',
+        # 'sel_gal2',
         'cho_row1',
         'mee_spe1',
         'res_wav1',
@@ -301,6 +301,14 @@ class StageOne(HubbleStage):
         self.stage_state.waveline_set = True
         index = self.galaxy_table.index
         self.update_data_value("student_measurements", "measwave", value, index)
+        
+        #set up to auto fill velocity when wavelength is measured
+        data = self.get_data("student_measurements")
+        lamb_rest = data["restwave"][index]
+        velocity = int(3 * (10 ** 5) * (value/lamb_rest - 1))
+        self.update_data_value("student_measurements", "velocity", velocity, index)
+        print(velocity)
+
 
     def vue_add_current_velocity(self, _args=None):
         data = self.get_data("student_measurements")

--- a/cosmicds/stories/hubbles_law/stages/stage_one.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.py
@@ -361,6 +361,9 @@ class StageOne(HubbleStage):
         if not flagged:
             return
         index = self.galaxy_table.index
+        item = self.galaxy_table.selected[0]
+        galaxy_name = item["name"]
+        self.remove_measurement(galaxy_name)
         galaxy = self._replace_galaxy_at_index(index)
         self.galaxy_table._populate_table()
         self.galaxy_table.selected = [galaxy]

--- a/cosmicds/stories/hubbles_law/stages/stage_one.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.py
@@ -87,7 +87,7 @@ class StageOne(HubbleStage):
 
     @default('subtitle')
     def _default_subtitle(self):
-        return "Perhaps a small blurb about this stage"
+        return ""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cosmicds/stories/hubbles_law/stages/stage_one.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.py
@@ -187,7 +187,7 @@ class StageOne(HubbleStage):
 
         def reset(flag):
             if flag:
-                self.marker = self.markers[0]
+                self.stage_state.marker = self.stage_state.markers[0]
         add_callback(self.story_state, 'reset_flag', reset)
 
     def _on_marker_update(self, old, new):

--- a/cosmicds/stories/hubbles_law/stages/stage_one.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.py
@@ -327,6 +327,7 @@ class StageOne(HubbleStage):
         lamb_rest = data["restwave"][index]
         velocity = int(3 * (10 ** 5) * (value/lamb_rest - 1))
         self.update_data_value("student_measurements", "velocity", velocity, index)
+        self.story_state.update_student_data()
 
 
     def vue_add_current_velocity(self, _args=None):
@@ -337,6 +338,7 @@ class StageOne(HubbleStage):
             lamb_meas = data["measwave"][index]
             velocity = int(3 * (10 ** 5) * (lamb_meas/lamb_obs - 1))
             self.update_data_value("student_measurements", "velocity", velocity, index)
+            self.story_state.update_student_data()
 
     @property
     def selection_tool(self):

--- a/cosmicds/stories/hubbles_law/stages/stage_one.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.vue
@@ -7,6 +7,7 @@
           class="black--text"
           @click="select_galaxies();"
         >select 5 galaxies</v-btn>
+        <!--
         <v-btn
           color="error"
           class="black--text"
@@ -14,7 +15,8 @@
         >fill data points</v-btn>
         <v-btn
           @click="console.log(stage_state)"
-        >State</v-btn>
+        >State</v-btn> 
+        -->
       </v-col>
     </v-row>
 
@@ -23,17 +25,20 @@
         cols="12"
         lg="4"
       >
+            <!--
         <c-stage-one-start-guidance
           v-if="stage_state.marker == 'mee_gui1'" />
         <c-select-galaxies-alert
           v-if="stage_state.marker == 'sel_gal1'" />
         <c-select-galaxies-2-guidance
           v-if="stage_state.marker == 'sel_gal2'" />
+          -->
       </v-col>
       <v-col
         cols="12"
         lg="8"
       >
+      <!--
         <v-card
           :color="stage_state.marker == 'sel_gal1' || stage_state.marker == 'sel_gal2' ? 'info' : 'black'"
           :class="stage_state.marker == 'sel_gal1' || stage_state.marker == 'sel_gal2' ? 'pa-1' : 'pa-0'"
@@ -42,11 +47,14 @@
           <c-selection-tool/>
           <!-- <v-card-actions>
             <v-btn @click="story_state.step_index += 1; story_state.step_complete = true">Next Step</v-btn>
-          </v-card-actions> -->
+          </v-card-actions> 
         </v-card>
+                  -->
       </v-col>
+      <!--
     </v-row>
     <v-row>
+      -->
       <v-col
         cols="12"
         lg="4"
@@ -115,11 +123,26 @@
     </v-row>
     <v-row>
       <v-col cols="12" lg="8" offset-lg="4">
+            <v-btn
+              class="white-text px-a"
+              width="100%"
+              color="success"
+              @click="
+                stage_state.marker = story_state.stage_index = 2;
+              "
+            >
+              Done with velocities
+            </v-btn>        
+      </v-col>
+    </v-row>
+    <!--
+    <v-row>
+      <v-col cols="12" lg="8" offset-lg="4">
         <v-row>
           <v-col
             cols="6"
           >
-            <!-- This alert is temporary -->
+            <!-- This alert is temporary --
             <v-btn
               :disabled="!stage_state.waveline_set"
               class="white-text px-a"
@@ -135,7 +158,7 @@
           <v-col
             cols="3"
           >
-            <!-- FORM DIALOG as template for reflections/MC -->
+            <!-- FORM DIALOG as template for reflections/MC --
             <c-spectrum-slideshow v-if="stage_state.indices[stage_state.marker] >= stage_state.indices['mee_spe1']" />
           </v-col>
           <v-col
@@ -144,7 +167,7 @@
             <span
               v-if="stage_state.waveline_set" 
             >
-              <!-- FORM DIALOG as template for reflections/MC -->
+              <!-- FORM DIALOG as template for reflections/MC --
               <reflect-velocity-windows
                 button-text="reflect"
                 close-text="submit"
@@ -159,5 +182,6 @@
         </v-row>
       </v-col>
     </v-row>
+            -->
   </v-container>
 </template>

--- a/cosmicds/stories/hubbles_law/stages/stage_one.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.vue
@@ -1,17 +1,14 @@
 <template>
   <v-container>
+            <!--
     <v-row>
       <v-col>
         <v-btn
           color="error"
           class="black--text"
-          @click="select_galaxies();"
-        >select 5 galaxies</v-btn>
-        <v-btn
-          color="error"
-          class="black--text"
           @click="console.dir(app_state.student)"
         >show student data</v-btn>
+        -->
         <!--
         <v-btn
           color="error"
@@ -21,15 +18,16 @@
         <v-btn
           @click="console.log(stage_state)"
         >State</v-btn> 
-        -->
       </v-col>
     </v-row>
+    -->
 
     <v-row>
       <v-col
         cols="12"
         lg="4"
       >
+
             <!--
         <c-stage-one-start-guidance
           v-if="stage_state.marker == 'mee_gui1'" />
@@ -64,6 +62,23 @@
         cols="12"
         lg="4"
       >
+        <v-btn
+          class="white-text px-a"
+          color="success"
+          @click="select_galaxies();"
+        >select 5 galaxies</v-btn>
+        <v-divider
+          class="my-3"
+          >
+        </v-divider>
+        <v-card
+          class="pa-4"
+          color="info"
+          elevation="6"
+        >
+          Click a row to display the spectrum.
+        </v-card>
+          <!--      
         <c-choose-row-guidance
           v-if="stage_state.marker == 'cho_row1'" />
         <c-doppler-calc-3-guidance
@@ -74,7 +89,7 @@
           v-if="stage_state.marker == 'dop_cal5'"/>
         <c-doppler-calc-6-component
           v-if="stage_state.marker == 'dop_cal6'"/> 
-          
+          -->
       </v-col>
       <v-col
         cols="12"
@@ -95,6 +110,19 @@
         cols="12"
         lg="4"
       >
+        <v-card
+          class="pa-4"
+          color="info"
+          elevation="6"
+        >
+          <ul>
+            <li>Zoom in to region around line</li>
+            <li>Align vertical measuring tool to line and click to record wavelength and velocity</li>
+            <li>If line looks incorrect (for example, if there does not appear to be a strong Mg-I line) click the flag.</li>
+            <li>Repeat for all 5 galaxies and click "Go to Distance Measurement" to move on</li>            
+          </ul>
+        </v-card>
+        <!--
         <c-spectrum-guidance 
           v-if="stage_state.marker == 'mee_spe1'"/>
         <c-restwave-alert
@@ -110,7 +138,8 @@
         <c-doppler-calc-1-alert
           v-if="stage_state.marker == 'dop_cal1'" />
         <c-doppler-calc-2-alert
-          v-if="stage_state.marker == 'dop_cal2'" />            
+          v-if="stage_state.marker == 'dop_cal2'" />    
+          -->        
       </v-col>
       <v-col
         cols="12"
@@ -127,17 +156,18 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" lg="8" offset-lg="4">
-            <v-btn
-              class="white-text px-a"
-              width="100%"
-              color="success"
-              @click="
-                story_state.stage_index = 2;
-              "
-            >
-              Done with velocities
-            </v-btn>        
+      <v-col cols="9">
+      </v-col>
+      <v-col cols="3">
+        <v-btn
+          class="white-text px-a"
+          color="success"
+          @click="
+            story_state.stage_index = 2;
+          "
+        >
+          Go to Distance Measurement
+        </v-btn>        
       </v-col>
     </v-row>
     <!--

--- a/cosmicds/stories/hubbles_law/stages/stage_one.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.vue
@@ -7,6 +7,11 @@
           class="black--text"
           @click="select_galaxies();"
         >select 5 galaxies</v-btn>
+        <v-btn
+          color="error"
+          class="black--text"
+          @click="console.dir(app_state.student)"
+        >show student data</v-btn>
         <!--
         <v-btn
           color="error"

--- a/cosmicds/stories/hubbles_law/stages/stage_one.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.vue
@@ -128,7 +128,7 @@
               width="100%"
               color="success"
               @click="
-                stage_state.marker = story_state.stage_index = 2;
+                story_state.stage_index = 2;
               "
             >
               Done with velocities

--- a/cosmicds/stories/hubbles_law/stages/stage_three.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_three.py
@@ -1,3 +1,4 @@
+from echo import add_callback
 from glue.core.message import NumericalDataChangedMessage
 from glue.core.state_objects import State
 from traitlets import default
@@ -44,6 +45,8 @@ class StageThree(HubbleStage):
         fit_viewer.state.x_att = student_data.id['distance']
         fit_viewer.state.y_att = student_data.id['velocity']
 
+        add_callback(self.story_state, "reset_flag", self._on_reset)
+
         # Whenever the student data is updated, the student scatter viewer should update its bounds
         self.hub.subscribe(self, NumericalDataChangedMessage,
                            handler=self._on_student_data_change, filter=self._student_data_filter)
@@ -54,3 +57,10 @@ class StageThree(HubbleStage):
     def _on_student_data_change(self, msg):
         viewer = self.get_viewer("fit_viewer")
         viewer.state.reset_limits()
+
+    def _on_reset(self, flag):
+        print(flag)
+        if flag:
+            fit_viewer = self.get_viewer("fit_viewer")
+            fit_tool = fit_viewer.toolbar.tools["cds:linefit"]
+            fit_tool.deactivate()

--- a/cosmicds/stories/hubbles_law/stages/stage_three.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_three.py
@@ -1,16 +1,12 @@
-from glue.core import Data
+from glue.core.message import NumericalDataChangedMessage
 from glue.core.state_objects import State
 from traitlets import default
 
-from cosmicds.components.table import Table
 from cosmicds.registries import register_stage
 from cosmicds.stories.hubbles_law.stage import HubbleStage
-from cosmicds.phases import Stage
-from cosmicds.utils import extend_tool, load_template, update_figure_css
-from cosmicds.viewers import CDSHistogramView, CDSScatterView
+from cosmicds.utils import load_template
 
-from cosmicds.stories.hubbles_law.histogram_listener import HistogramListener
-from cosmicds.stories.hubbles_law.viewers import CDSFitView
+from cosmicds.stories.hubbles_law.viewers import HubbleFitView
 
 class StageState(State):
     pass
@@ -41,162 +37,20 @@ class StageThree(HubbleStage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # measurements = self.get_data("student_measurements")
-        # fit_table = Table(self.session,
-        #                   data=measurements,
-        #                   glue_components=['ID',
-        #                                   'Type',
-        #                                   'velocity',
-        #                                   'distance'],
-        #                   key_component='ID',
-        #                   names=['Galaxy Name',
-        #                       'Galaxy Type',
-        #                       'Velocity (km/s)',
-        #                       'Distance (Mpc)'],
-        #                   title='My Galaxies')
-        # self.add_widget(fit_table, label="fit_table")
+        fit_viewer = self.add_viewer(HubbleFitView, "fit_viewer", "My Data")
+        student_data = self.get_data("student_data")
+        fit_viewer.ignore(lambda x: x.label != student_data.label)
+        fit_viewer.add_data(student_data)
+        fit_viewer.state.x_att = student_data.id['distance']
+        fit_viewer.state.y_att = student_data.id['velocity']
 
-        # student_data = self.get_data("student_data")
-        # all_data = self.get_data("HubbleData_All")
+        # Whenever the student data is updated, the student scatter viewer should update its bounds
+        self.hub.subscribe(self, NumericalDataChangedMessage,
+                           handler=self._on_student_data_change, filter=self._student_data_filter)
 
+    def _student_data_filter(self, msg):
+        return msg.data == self.get_data("student_data")
 
-        # # Set up links between various data sets
-        # student_dc_name = "student_data"
-        # class_dc_name = "HubbleData_ClassSample"
-        # all_dc_name = "HubbleData_All"
-        # hubble_name = "Hubble 1929-Table 1"
-        # hstkp_name = "HSTkey2001"
-
-        # class_data = self.get_data(class_dc_name)
-        # for component in class_data.components:
-        #     field = component.label
-        #     self.add_link(class_dc_name, field, all_dc_name, field)
-        #     if component.label in student_data.component_ids():
-        #         self.add_link(student_dc_name, field, class_dc_name, field)
-        # self.add_link(hubble_name, 'Distance (Mpc)', hstkp_name, 'Distance (Mpc)')
-        # self.add_link(hubble_name, 'Tweaked Velocity (km/s)', hstkp_name, 'Velocity (km/s)')
-        # self.add_link(hstkp_name, 'Distance (Mpc)', student_dc_name, 'distance')
-        # self.add_link(hstkp_name, 'Velocity (km/s)', student_dc_name, 'velocity')
-
-
-        # students_viewer = self.add_viewer(CDSScatterView, "students_viewer", "Student Data")
-        # fit_viewer = self.add_viewer(CDSFitView, "fit_viewer", "My Data")
-        # comparison_viewer = self.add_viewer(CDSScatterView, "comparison_viewer", "Data Comparison")
-        # morphology_viewer = self.add_viewer(CDSScatterView, "morphology_viewer", "Galaxy Morphology")
-        # prodata_viewer = self.add_viewer(CDSScatterView, "prodata_viewer", "Professional Data")
-        # for viewer in [students_viewer, fit_viewer, comparison_viewer, prodata_viewer]:
-        #     viewer.add_data(student_data)
-        #     #viewer.layers[-1].state.visible = False
-        #     viewer.state.x_att = student_data.id['distance']
-        #     viewer.state.y_att = student_data.id['velocity']
-
-
-        # students_viewer.add_data(class_data)
-        # students_viewer.state.x_att = class_data.id['distance']
-        # students_viewer.state.y_att = class_data.id['velocity']
-        # students_viewer.layers[-1].state.zorder = 2
-        
-        # comparison_viewer.layers[-1].state.zorder = 3
-        # comparison_viewer.add_data(class_data)
-        # comparison_viewer.layers[-1].state.zorder = 2
-        # comparison_viewer.add_data(all_data)
-        # comparison_viewer.layers[-1].state.zorder = 1
-        # comparison_viewer.state.x_att = all_data.id['distance']
-        # comparison_viewer.state.y_att = all_data.id['velocity']
-        # comparison_viewer.state.reset_limits()
-        
-        # hubble1929 = self.get_data("Hubble 1929-Table 1")
-        # hstkp = self.get_data("HSTkey2001")
-        # prodata_viewer.add_data(student_data)
-        # prodata_viewer.state.x_att = student_data.id['distance']
-        # prodata_viewer.state.y_att = student_data.id['velocity']
-        # prodata_viewer.add_data(hstkp)
-        # prodata_viewer.add_data(hubble1929)
-
-        # class_distr_viewer = self.add_viewer(CDSHistogramView, 'class_distr_viewer')
-        # all_distr_viewer = self.add_viewer(CDSHistogramView, 'all_distr_viewer')
-        # sandbox_distr_viewer = self.add_viewer(CDSHistogramView, 'sandbox_distr_viewer')
-        # class_sample_data = self.get_data("HubbleSummary_ClassSample")
-        # students_summary_data = self.get_data("HubbleSummary_Students")
-        # classes_summary_data = self.get_data("HubbleSummary_Classes")
-        # histogram_viewers = [class_distr_viewer, all_distr_viewer, sandbox_distr_viewer]
-        # for viewer in histogram_viewers:
-        #     label = 'Count' if viewer == class_distr_viewer else 'Proportion'
-        #     viewer.figure.axes[1].label = label
-        #     if viewer != all_distr_viewer:
-        #         viewer.add_data(class_sample_data)
-        #         layer = viewer.layers[-1]
-        #         layer.state.color = 'red'
-        #         layer.state.alpha = 0.5
-        #     if viewer != class_distr_viewer:
-        #         viewer.add_data(students_summary_data)
-        #         layer = viewer.layers[-1]
-        #         layer.state.color = 'blue'
-        #         layer.state.alpha = 0.5
-        #         viewer.add_data(classes_summary_data)
-        #         layer = viewer.layers[-1]
-        #         layer.state.color = '#f0c470'
-        #         layer.state.alpha = 0.5
-        #         viewer.state.normalize = True
-        #         viewer.state.y_min = 0
-        #         viewer.state.y_max = 1
-        #         viewer.state.hist_n_bin = 30
-    
-        # class_distr_viewer.state.x_att = class_sample_data.id['age']
-        # all_distr_viewer.state.x_att = students_summary_data.id['age']
-        # sandbox_distr_viewer.state.x_att = students_summary_data.id['age']
-
-        # galaxy_data = self.get_data('galaxy_data')
-        # type_field = 'MorphType'
-        # elliptical_subset = galaxy_data.new_subset(galaxy_data.id[type_field] == 'E', label='Elliptical', color='orange')
-        # spiral_subset = galaxy_data.new_subset(galaxy_data.id[type_field] == 'Sp', label='Spiral', color='green')
-        # irregular_subset = galaxy_data.new_subset(galaxy_data.id[type_field] == 'Ir', label='Irregular', color='red')
-        # morphology_subsets = [elliptical_subset, spiral_subset, irregular_subset]
-        # for subset in morphology_subsets:
-        #     morphology_viewer.add_subset(subset)
-        # morphology_viewer.state.x_att = galaxy_data.id['EstDist_Mpc']
-        # morphology_viewer.state.y_att = galaxy_data.id['velocity_km_s']
-
-        # Set up the listener to sync the histogram <--> scatter viewers
-    #    meas_data = self.get_data("HubbleData_ClassSample")
-    #    hist_sync_sg = self.data_collection.new_subset_group(label="Hist Sync SG")
-    #   scatter_sync_sg = self.data_collection.new_subset_group(label="Scatter Sync SG")
-    #    hist_sync_sg.style.color = "green"
-    #    scatter_sync_sg.style.color = "green"
-
-        # Right now, this is the only viewer aside from the synced viewers
-        # that shows these data objects
-    #    for layer in sandbox_distr_viewer.layers:
-    #        if layer.state.layer.label in [hist_sync_sg.label, scatter_sync_sg.label]:
-    #            layer.state.visible = False
-
-        # fit_table = self.get_widget("fit_table")
-        # subset_group_label = "fit_table" + '_selected'
-        # fit_table.subset_group = self.data_collection.new_subset_group(label=subset_group_label, subset_state=None)
-
-        # # Set up the functionality for the histogram <---> scatter sync
-        # # We add a listener for when a subset is modified/created on 
-        # # the histogram viewer as well as extend the xrange tool for the 
-        # # histogram to always affect this subset
-        # self.histogram_listener = HistogramListener(self.story_state,
-        #                                             hist_sync_sg,
-        #                                             classes_summary_data,
-        #                                             scatter_sync_sg, 
-        #                                             meas_data)
-
-        # def hist_selection_activate():
-        #     if self.histogram_listener.source is not None:
-        #         self.session.edit_subset_mode.edit_subset = [self.histogram_listener.source_group]
-        #     self.histogram_listener.listen()
-        # def hist_selection_deactivate():
-        #     self.session.edit_subset_mode.edit_subset = []
-        #     self.histogram_listener.ignore()
-        # extend_tool(class_distr_viewer, 'bqplot:xrange', hist_selection_activate, hist_selection_deactivate)
-
-        # # We want the hub_fit_viewer to be selecting for the same subset as the table
-        # def fit_selection_activate():
-        #     self.session.edit_subset_mode.edit_subset = [self.get_widget('fit_table').subset_group]
-        # def fit_selection_deactivate():
-        #     self.session.edit_subset_mode.edit_subset = []
-        # for tool_id in ['bqplot:xrange', 'bqplot:yrange', 'bqplot:rectangle', 'bqplot:circle']:
-        #     extend_tool(fit_viewer, tool_id, fit_selection_activate, fit_selection_deactivate)
+    def _on_student_data_change(self, msg):
+        viewer = self.get_viewer("fit_viewer")
+        viewer.state.reset_limits()

--- a/cosmicds/stories/hubbles_law/stages/stage_three.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_three.py
@@ -33,7 +33,7 @@ class StageThree(HubbleStage):
 
     @default('subtitle')
     def _default_subtitle(self):
-        return "Perhaps a small blurb about this stage"
+        return ""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cosmicds/stories/hubbles_law/stages/stage_three.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_three.vue
@@ -1,6 +1,13 @@
 <template>
   <v-container>
     <v-row>
+      <v-col cols="12">
+        <v-btn
+          @click="story_state.stage_index = 2"
+        >back</v-btn>
+      </v-col>
+    </v-row>
+    <v-row>
       <v-col cols="6">
         <jupyter-widget :widget="widgets.fit_table"/>
       </v-col>

--- a/cosmicds/stories/hubbles_law/stages/stage_two.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.py
@@ -4,7 +4,7 @@ from astropy.modeling import fitting, models
 from echo import CallbackProperty, add_callback, ignore_callback
 from glue.core.state_objects import State
 from numpy import pi
-from traitlets import default
+from traitlets import default, Bool, Float
 from cosmicds.events import WriteToDatabaseMessage
 
 from cosmicds.stories.hubbles_law.components.distance_sidebar import DistanceSidebar
@@ -48,6 +48,8 @@ class StageState(State):
     "Measure distances"
 ])
 class StageTwo(HubbleStage):
+    age_to_display = Float(0).tag(sync=True)
+    display_age = Bool(False).tag(sync=True)
 
     @default('template')
     def _default_template(self):
@@ -134,6 +136,8 @@ class StageTwo(HubbleStage):
         h0 = self._find_H0()
         age = age_in_gyr_simple(h0)
         self.story_state.calculations["age_value"] = age
+        self.age_to_display = age
+        self.display_age = True
         self.hub.broadcast(WriteToDatabaseMessage(self))
 
     def vue_start_over(self, _args=None):

--- a/cosmicds/stories/hubbles_law/stages/stage_two.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.py
@@ -1,6 +1,7 @@
 import logging
 
 from astropy.modeling import fitting, models
+import astropy.units as u
 from echo import CallbackProperty, add_callback, ignore_callback
 from glue.core.state_objects import State
 from numpy import pi
@@ -116,12 +117,14 @@ class StageTwo(HubbleStage):
 
     def _make_measurement(self):
         galaxy = self.stage_state.galaxy
-        index = self.get_data_index('student_measurements', 'name', lambda x: x == galaxy["name"])
-        angular_size = self.distance_tool.angular_size.value
-        distance = round(MILKY_WAY_SIZE_MPC * 180 / (angular_size * pi))
+        index = self.get_data_indices('student_measurements', 'name', lambda x: x == galaxy["name"], single=True)
+        angular_size = self.distance_tool.angular_size
+        ang_size_deg = angular_size.value
+        distance = round(MILKY_WAY_SIZE_MPC * 180 / (ang_size_deg * pi))
+        angular_size_as = round(angular_size.to(u.arcsec).value)
         self.stage_state.galaxy_dist = distance
         self.update_data_value("student_measurements", "distance", distance, index)
-        self.update_data_value("student_measurements", "angular_size", angular_size, index)
+        self.update_data_value("student_measurements", "angular_size", angular_size_as, index)
         self.story_state.update_student_data()
 
     def _find_H0(self):

--- a/cosmicds/stories/hubbles_law/stages/stage_two.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.py
@@ -9,7 +9,7 @@ from cosmicds.stories.hubbles_law.components.distance_sidebar import DistanceSid
 from cosmicds.stories.hubbles_law.components.distance_tool import DistanceTool
 from cosmicds.components.table import Table
 from cosmicds.registries import register_stage
-from cosmicds.stories.hubbles_law.utils import GALAXY_FOV, MILKY_WAY_SIZE_MPC, format_fov, format_measured_angle
+from cosmicds.stories.hubbles_law.utils import FULL_FOV, GALAXY_FOV, MILKY_WAY_SIZE_MPC, format_fov, format_measured_angle
 from cosmicds.utils import load_template
 from cosmicds.stories.hubbles_law.stage import HubbleStage
 
@@ -103,8 +103,9 @@ class StageTwo(HubbleStage):
         self.distance_tool.measuring_allowed = bool(galaxy)
 
     def _angular_size_update(self, change):
-        self.distance_sidebar.angular_size = format_fov(change["new"])
-        if self.distance_sidebar.angular_size != 0:
+        new_ang_size = change["new"]
+        self.distance_sidebar.angular_size = format_fov(new_ang_size)
+        if new_ang_size !=0 and new_ang_size is not None:
             self._make_measurement()
 
     def _angular_height_update(self, change):
@@ -120,7 +121,11 @@ class StageTwo(HubbleStage):
         self.update_data_value("student_measurements", "angular_size", angular_size, index)
         self.story_state.update_student_data()
 
-        
+    def vue_start_over(self, _args=None):
+        self.app_state.reset_student = True
+        self.distance_tool.reset_canvas()
+        self.distance_tool.go_to_location(0, 0, FULL_FOV)
+        self.story_state.start_over()
 
     @property
     def distance_sidebar(self):

--- a/cosmicds/stories/hubbles_law/stages/stage_two.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.py
@@ -69,11 +69,13 @@ class StageTwo(HubbleStage):
                                data=self.get_data('student_measurements'),
                                glue_components=['name',
                                                'velocity',
-                                               'distance'],
+                                               'distance',
+                                               'angular_size'],
                                key_component='name',
                                names=['Galaxy Name',
                                        'Velocity (km/s)',
-                                       'Distance (Mpc)'],
+                                       'Distance (Mpc)',
+                                       'Angular Size'],
                                title='My Galaxies | Distance Measurements',
                                single_select=True)
         self.add_widget(distance_table, label="distance_table")

--- a/cosmicds/stories/hubbles_law/stages/stage_two.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.py
@@ -145,6 +145,7 @@ class StageTwo(HubbleStage):
         self.app_state.reset_student = True
         self.distance_tool.reset_canvas()
         self.distance_tool.go_to_location(0, 0, FULL_FOV)
+        self.display_age = False
         self.story_state.start_over()
 
     @property

--- a/cosmicds/stories/hubbles_law/stages/stage_two.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.py
@@ -103,6 +103,7 @@ class StageTwo(HubbleStage):
         self.stage_state.galaxy = galaxy
         self.stage_state.galaxy_dist = None
         self.distance_tool.measuring_allowed = bool(galaxy)
+        self.distance_tool.galaxy = galaxy
 
     def _angular_size_update(self, change):
         new_ang_size = change["new"]

--- a/cosmicds/stories/hubbles_law/stages/stage_two.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.py
@@ -55,11 +55,11 @@ class StageTwo(HubbleStage):
 
     @default('title')
     def _default_title(self):
-        return "Another Stage Name"
+        return "Distance Measurements"
 
     @default('subtitle')
     def _default_subtitle(self):
-        return "Perhaps a small blurb about this stage"
+        return ""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cosmicds/stories/hubbles_law/stages/stage_two.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.py
@@ -90,6 +90,8 @@ class StageTwo(HubbleStage):
         self.distance_tool.observe(self._angular_height_update, names=["angular_height"])
         self.distance_sidebar.angular_height = format_fov(self.distance_tool.angular_height)
 
+        self.distance_tool.observe(self._distance_tool_flagged, names=["flagged"])
+
     def distance_table_selected_change(self, change):
         selected = change["new"]
         if not selected or selected == change["old"]:
@@ -150,6 +152,20 @@ class StageTwo(HubbleStage):
         self.distance_tool.go_to_location(0, 0, FULL_FOV)
         self.display_age = False
         self.story_state.start_over()
+
+    def _distance_tool_flagged(self, change):
+        if not change["new"]:
+            return
+        index = self.distance_table.index
+        if index is None:
+            return
+        item = self.distance_table.selected[0]
+        galaxy_name = item["name"]
+        self.remove_measurement(galaxy_name)
+        galaxy = self._replace_galaxy_at_index(index)
+        self.distance_table._populate_table()
+        self.distance_table.selected = [galaxy]
+        self.distance_tool.flagged = False
 
     @property
     def distance_sidebar(self):

--- a/cosmicds/stories/hubbles_law/stages/stage_two.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.py
@@ -1,22 +1,23 @@
 import logging
 
-from echo import CallbackProperty, add_callback
+from echo import CallbackProperty, add_callback, ignore_callback
 from glue.core.state_objects import State
+from numpy import pi
 from traitlets import default
 
 from cosmicds.stories.hubbles_law.components.distance_sidebar import DistanceSidebar
 from cosmicds.stories.hubbles_law.components.distance_tool import DistanceTool
 from cosmicds.components.table import Table
 from cosmicds.registries import register_stage
-from cosmicds.stories.hubbles_law.utils import GALAXY_FOV, format_fov, format_measured_angle
+from cosmicds.stories.hubbles_law.utils import GALAXY_FOV, MILKY_WAY_SIZE_MPC, format_fov, format_measured_angle
 from cosmicds.utils import load_template
 from cosmicds.stories.hubbles_law.stage import HubbleStage
 
 log = logging.getLogger()
 
 class StageState(State):
-    selected_galaxy = CallbackProperty({})
-    make_measurement = CallbackProperty(False)
+    galaxy = CallbackProperty({})
+    galaxy_dist = CallbackProperty(None)
     marker = CallbackProperty("")
     advance_marker = CallbackProperty(True)
 
@@ -84,8 +85,7 @@ class StageTwo(HubbleStage):
         self.add_component(DistanceSidebar(self.stage_state), label="c-distance-sidebar")
         self.distance_tool.observe(self._angular_size_update, names=["angular_size"])
         self.distance_tool.observe(self._angular_height_update, names=["angular_height"])
-
-        add_callback(self.stage_state, 'make_measurement', self._make_measurement)
+        self.distance_sidebar.angular_height = format_fov(self.distance_tool.angular_height)
 
     def distance_table_selected_change(self, change):
         selected = change["new"]
@@ -95,22 +95,30 @@ class StageTwo(HubbleStage):
         index = self.distance_table.index
         data = self.distance_table.glue_data
         galaxy = { x.label : data[x][index] for x in data.main_components }
+        self.distance_tool.reset_canvas()
         self.distance_tool.go_to_location(galaxy["ra"], galaxy["decl"], fov=GALAXY_FOV)
 
-        self.stage_state.selected_galaxy = galaxy
+        self.stage_state.galaxy = galaxy
+        self.stage_state.galaxy_dist = None
         self.distance_tool.measuring_allowed = bool(galaxy)
 
     def _angular_size_update(self, change):
         self.distance_sidebar.angular_size = format_fov(change["new"])
+        if self.distance_sidebar.angular_size != 0:
+            self._make_measurement()
 
     def _angular_height_update(self, change):
         self.distance_sidebar.angular_height = format_measured_angle(change["new"])
 
-    def _make_measurement(self, value):
-        if not value:
-            return
-        galaxy = self.stage_state.selected_galaxy
-        index = self.get_data_index('student_data', 'id', lambda x: x == galaxy["id"])
+    def _make_measurement(self):
+        galaxy = self.stage_state.galaxy
+        index = self.get_data_index('student_measurements', 'name', lambda x: x == galaxy["name"])
+        angular_size = self.distance_tool.angular_size.value
+        distance = round(MILKY_WAY_SIZE_MPC * 180 / (angular_size * pi))
+        self.stage_state.galaxy_dist = distance
+        self.update_data_value("student_measurements", "distance", distance, index)
+        self.update_data_value("student_measurements", "angular_size", angular_size, index)
+        self.story_state.update_student_data()
 
         
 

--- a/cosmicds/stories/hubbles_law/stages/stage_two.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.vue
@@ -51,12 +51,20 @@
       <v-col cols="4">
         <v-spacer></v-spacer>
       </v-col>
-      <v-col cols="1">
+      <v-col cols="2" class="text-right">
         <v-btn
           class="white-text px-a"
           color="success"
           @click="submit_age()"
         >submit age</v-btn>
+        <v-card 
+          v-if="display_age"
+          class="pa-2 mt-2"
+          elevation="6"
+          outlined 
+        >
+          Estimated age: {{ age_to_display }} Gy
+        </v-card>
       </v-col>      
     </v-row>    
     <v-row>
@@ -72,7 +80,7 @@
       <v-col cols="4">
         <v-spacer></v-spacer>
       </v-col>
-      <v-col cols="1">
+      <v-col cols="2" class="text-right">
         <v-btn
           class="white-text px-a"
           color="success"
@@ -84,7 +92,7 @@
       <v-col cols="7">
         <v-spacer></v-spacer>
       </v-col>
-      <v-col cols="1">
+      <v-col cols="3" class="text-right">
         <v-btn
           class="white-text px-a"
           color="accent"

--- a/cosmicds/stories/hubbles_law/stages/stage_two.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.vue
@@ -10,6 +10,17 @@
       </v-col>
     </v-row>
 
+    <v-row class="d-flex align-stretch">
+      <v-col cols="4">
+        <c-distance-sidebar/>
+      </v-col>
+      <v-col cols="6">
+        <v-card class="align-self-stretch">
+          <c-distance-tool/>
+        </v-card>
+      </v-col>
+    </v-row>
+
     <v-row>
       <v-col cols="4">
         <v-card
@@ -24,17 +35,6 @@
       </v-col>
       <v-col cols="6">
         <jupyter-widget :widget="widgets.distance_table"/>      
-      </v-col>
-    </v-row>
-
-    <v-row class="d-flex align-stretch">
-      <v-col cols="4">
-        <c-distance-sidebar/>
-      </v-col>
-      <v-col cols="6">
-        <v-card class="align-self-stretch">
-          <c-distance-tool/>
-        </v-card>
       </v-col>
     </v-row>
 

--- a/cosmicds/stories/hubbles_law/stages/stage_two.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.vue
@@ -1,9 +1,16 @@
 <template>
   <v-container>
+    <v-row>
+      <v-col cols="1">
+        <v-btn
+          @click="story_state.stage_index = 1"
+        >back</v-btn>
+        <v-btn
+          @click="story_state.start_over()"
+        >start over</v-btn>
+      </v-col>
+    </v-row>
     <v-row class="d-flex align-stretch">
-      <v-btn
-        @click="story_state.stage_index = 1"
-      >back</v-btn>
       <v-col cols="6">
         <v-card class="align-self-stretch">
           <c-distance-tool/>

--- a/cosmicds/stories/hubbles_law/stages/stage_two.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.vue
@@ -1,43 +1,96 @@
 <template>
   <v-container>
     <v-row>
-      <v-col cols="2">
+      <v-col cols="4">
         <v-btn
+          class="white-text px-a"
+          color="success"
           @click="story_state.stage_index = 1"
-        >back</v-btn>
-        <v-btn
-          @click="story_state.stage_index = 3"
-        >next</v-btn>
-      </v-col>
-      <v-col cols="3">
-        <v-spacer></v-spacer>
-      </v-col>
-      <v-col>
-        <v-btn
-          @click="submit_age()"
-        >submit age</v-btn>
-      </v-col>
-      <v-col cols="3">
-        <v-spacer></v-spacer>
-      </v-col>
-      <v-col cols="1">
-        <v-btn
-          @click="start_over()"
-        >start over</v-btn>
+        >Go back to Velocities</v-btn>
       </v-col>
     </v-row>
+
+    <v-row>
+      <v-col cols="4">
+        <v-card
+          class="pa-4"
+          color="info"
+          elevation="6"
+        >
+          Click a row to display the galaxy.
+          <p>Click the ruler icon to activate the measuring tool and mark the edges of the galaxy.</p> 
+          <p>Complete for all 5 galaxies</p>
+        </v-card>        
+      </v-col>
+      <v-col cols="6">
+        <jupyter-widget :widget="widgets.distance_table"/>      
+      </v-col>
+    </v-row>
+
     <v-row class="d-flex align-stretch">
+      <v-col cols="4">
+        <c-distance-sidebar/>
+      </v-col>
       <v-col cols="6">
         <v-card class="align-self-stretch">
           <c-distance-tool/>
         </v-card>
       </v-col>
-      <v-col cols="3">
-        <c-distance-sidebar/>
-      </v-col>
     </v-row>
+
     <v-row>
-      <jupyter-widget :widget="widgets.distance_table"/>
-    </v-row>
+      <v-col cols="4">
+        <v-card
+          class="pa-4"
+          color="info"
+          elevation="6"
+        >
+          Click "Submit Age" to store result in database.
+        </v-card>           
+      </v-col>
+      <v-col cols="4">
+        <v-spacer></v-spacer>
+      </v-col>
+      <v-col cols="1">
+        <v-btn
+          class="white-text px-a"
+          color="success"
+          @click="submit_age()"
+        >submit age</v-btn>
+      </v-col>      
+    </v-row>    
+    <v-row>
+      <v-col cols="4">
+        <v-card
+          class="pa-4"
+          color="info"
+          elevation="6"
+        >
+          Click "Start Over" to create entry for a new student.
+        </v-card>           
+      </v-col>
+      <v-col cols="4">
+        <v-spacer></v-spacer>
+      </v-col>
+      <v-col cols="1">
+        <v-btn
+          class="white-text px-a"
+          color="success"
+          @click="start_over()"
+        >start over</v-btn>
+      </v-col>      
+    </v-row>   
+    <v-row>
+      <v-col cols="7">
+        <v-spacer></v-spacer>
+      </v-col>
+      <v-col cols="1">
+        <v-btn
+          class="white-text px-a"
+          color="accent"
+          @click="story_state.stage_index = 3"
+        >See Hubble Graph</v-btn>
+      </v-col>      
+    </v-row> 
   </v-container>
 </template>

--- a/cosmicds/stories/hubbles_law/stages/stage_two.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.vue
@@ -1,10 +1,26 @@
 <template>
   <v-container>
     <v-row>
-      <v-col cols="1">
+      <v-col cols="2">
         <v-btn
           @click="story_state.stage_index = 1"
         >back</v-btn>
+        <v-btn
+          @click="story_state.stage_index = 3"
+        >next</v-btn>
+      </v-col>
+      <v-col cols="3">
+        <v-spacer></v-spacer>
+      </v-col>
+      <v-col>
+        <v-btn
+          @click="submit_age()"
+        >submit age</v-btn>
+      </v-col>
+      <v-col cols="3">
+        <v-spacer></v-spacer>
+      </v-col>
+      <v-col cols="1">
         <v-btn
           @click="start_over()"
         >start over</v-btn>

--- a/cosmicds/stories/hubbles_law/stages/stage_two.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.vue
@@ -6,7 +6,7 @@
           @click="story_state.stage_index = 1"
         >back</v-btn>
         <v-btn
-          @click="story_state.start_over()"
+          @click="start_over()"
         >start over</v-btn>
       </v-col>
     </v-row>

--- a/cosmicds/stories/hubbles_law/stages/stage_two.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.vue
@@ -1,6 +1,9 @@
 <template>
   <v-container>
     <v-row class="d-flex align-stretch">
+      <v-btn
+        @click="story_state.stage_index = 1"
+      >back</v-btn>
       <v-col cols="6">
         <v-card class="align-self-stretch">
           <c-distance-tool/>

--- a/cosmicds/stories/hubbles_law/state.py
+++ b/cosmicds/stories/hubbles_law/state.py
@@ -173,7 +173,24 @@ class HubblesLaw(Story):
         student_data.update_values_from_data(new_data)
         self.make_data_writeable(student_data)
 
-    def vue_start_over(self):
+    def reset_data(self):
+        dc = self.data_collection
+        student_cols = ["id", "name", "ra", "decl", "z", "type", "measwave",
+                         "restwave", "student_id", "velocity", "distance",
+                         "element", "angular_size"]
+        student_measurements = Data(
+            label='student_measurements',
+            **{x: np.array([], dtype='float64')
+               for x in student_cols})
+        student_data = Data(
+            label="student_data",
+            **{x : ['X'] if x in ['id', 'element', 'type'] else [0] 
+                for x in student_cols})
+        dc["student_measurements"].update_values_from_data(student_measurements)
+        dc["student_data"].update_values_from_data(student_data)
+
+    def start_over(self):
+        self.reset_data()
         self.stage_index = 1
         self.reset_flag = True
         with ignore_callback(self, 'reset_flag'):

--- a/cosmicds/stories/hubbles_law/state.py
+++ b/cosmicds/stories/hubbles_law/state.py
@@ -10,6 +10,7 @@ import ipyvuetify as v
 
 import requests
 from cosmicds.utils import API_URL
+from cosmicds.stories.hubbles_law.utils import HUBBLE_ROUTE_PATH
 
 @story_registry(name="hubbles_law")
 class HubblesLaw(Story):
@@ -72,7 +73,7 @@ class HubblesLaw(Story):
         ])
 
         # Load in the galaxy data
-        galaxies = requests.get(f"{API_URL}/galaxies").json()
+        galaxies = requests.get(f"{API_URL}/{HUBBLE_ROUTE_PATH}/galaxies").json()
         self.data_collection.append(Data(
             label="SDSS_all_sample_filtered",
             **{ k : [x[k] for x in galaxies] for k in galaxies[0] }

--- a/cosmicds/stories/hubbles_law/state.py
+++ b/cosmicds/stories/hubbles_law/state.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from echo import DictCallbackProperty
+from echo import CallbackProperty, DictCallbackProperty, ignore_callback
 
 from cosmicds.phases import Story
 from cosmicds.registries import story_registry
@@ -44,6 +44,7 @@ class HubblesLaw(Story):
             "finished": True
         }
     })
+    reset_flag = CallbackProperty(False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -171,3 +172,9 @@ class HubblesLaw(Story):
         student_data = dc['student_data']
         student_data.update_values_from_data(new_data)
         self.make_data_writeable(student_data)
+
+    def vue_start_over(self):
+        self.stage_index = 1
+        self.reset_flag = True
+        with ignore_callback(self, 'reset_flag'):
+            self.reset_flag = False

--- a/cosmicds/stories/hubbles_law/tools/__init__.py
+++ b/cosmicds/stories/hubbles_law/tools/__init__.py
@@ -1,2 +1,3 @@
 from .rest_wavelength_tool import RestWavelengthTool
+from .spectrum_flag_tool import SpectrumFlagTool
 from .wavelength_zoom import WavelengthZoom

--- a/cosmicds/stories/hubbles_law/tools/__init__.py
+++ b/cosmicds/stories/hubbles_law/tools/__init__.py
@@ -1,1 +1,2 @@
 from .rest_wavelength_tool import RestWavelengthTool
+from .wavelength_zoom import WavelengthZoom

--- a/cosmicds/stories/hubbles_law/tools/spectrum_flag_tool.py
+++ b/cosmicds/stories/hubbles_law/tools/spectrum_flag_tool.py
@@ -1,0 +1,23 @@
+import requests
+
+from echo import CallbackProperty
+from glue.config import viewer_tool
+from glue.viewers.common.tool import Tool
+
+from cosmicds.utils import API_URL
+
+@viewer_tool
+class SpectrumFlagTool(Tool):
+
+    tool_id = "hubble:specflag"
+    action_text = "Flag a spectrum as bad"
+    tool_tip = "Flag a spectrum as bad"
+    mdi_icon = "mdi-flag"
+
+    flagged = CallbackProperty(False)
+
+    def activate(self):
+        data = { "galaxy_name": self.viewer.spectrum_name }
+        requests.post(f"{API_URL}/mark-spectrum-bad", json=data)
+        self.flagged = True
+

--- a/cosmicds/stories/hubbles_law/tools/spectrum_flag_tool.py
+++ b/cosmicds/stories/hubbles_law/tools/spectrum_flag_tool.py
@@ -5,6 +5,7 @@ from glue.config import viewer_tool
 from glue.viewers.common.tool import Tool
 
 from cosmicds.utils import API_URL
+from cosmicds.stories.hubbles_law.utils import HUBBLE_ROUTE_PATH
 
 @viewer_tool
 class SpectrumFlagTool(Tool):
@@ -18,6 +19,6 @@ class SpectrumFlagTool(Tool):
 
     def activate(self):
         data = { "galaxy_name": self.viewer.spectrum_name }
-        requests.post(f"{API_URL}/mark-spectrum-bad", json=data)
+        requests.post(f"{API_URL}/{HUBBLE_ROUTE_PATH}/mark-spectrum-bad", json=data)
         self.flagged = True
 

--- a/cosmicds/stories/hubbles_law/tools/wavelength_zoom.py
+++ b/cosmicds/stories/hubbles_law/tools/wavelength_zoom.py
@@ -1,0 +1,19 @@
+from cosmicds.tools import BqplotXZoom
+from glue.config import viewer_tool
+
+
+@viewer_tool #this decorator tells glue this is a viewer tool so it knows what to do with all this info
+class WavelengthZoom(BqplotXZoom):
+
+    icon = 'glue_zoom_to_rect'
+    mdi_icon = "mdi-select-drag"
+    tool_id = 'hubble:wavezoom'
+    action_text = 'x axis zoom'
+    tool_tip = 'Zoom in on a region of the x-axis'
+
+    def update_selection(self, *args):
+        if self.interact.brushing:
+            return
+        super().update_selection(*args)
+
+        self.deactivate()

--- a/cosmicds/stories/hubbles_law/utils.py
+++ b/cosmicds/stories/hubbles_law/utils.py
@@ -10,12 +10,15 @@ except ImportError:
     from astropy.cosmology import Planck15 as planck
 
 __all__ = [
+    'HUBBLE_ROUTE_PATH',
     'MILKY_WAY_SIZE_MPC', 'H_ALPHA_REST_LAMBDA',
     'MG_REST_LAMBDA', 'GALAXY_FOV', 'FULL_FOV',
     'angle_to_json', 'angle_from_json',
     'age_in_gyr', 'format_fov', 'format_measured_angle',
     'line_mark', 'vertical_line_mark',
 ]
+
+HUBBLE_ROUTE_PATH = "hubbles_law"
 
 MILKY_WAY_SIZE_MPC = 0.03
 

--- a/cosmicds/stories/hubbles_law/utils.py
+++ b/cosmicds/stories/hubbles_law/utils.py
@@ -20,8 +20,8 @@ __all__ = [
 MILKY_WAY_SIZE_MPC = 0.03
 
 # Both in angstroms
-H_ALPHA_REST_LAMBDA = 6563
-MG_REST_LAMBDA = 5177
+H_ALPHA_REST_LAMBDA = 6565 # SDSS calibrates to wavelengths in a vacuum,
+MG_REST_LAMBDA = 5172 # The value used by SDSS is actually 5176.7, but that wavelength aligns with an upward bump, so we are adjusting it to 5172 to avoid confusing students. Ziegler & Bender 1997 uses lambda_0 ~ 5170, so our choice is justifiable.
 
 GALAXY_FOV = 1.5 * u.arcmin
 FULL_FOV = 60 * u.deg

--- a/cosmicds/stories/hubbles_law/utils.py
+++ b/cosmicds/stories/hubbles_law/utils.py
@@ -54,6 +54,12 @@ def age_in_gyr(H0):
     unit = age.unit
     return age.value * unit.to(u.Gyr)
 
+def age_in_gyr_simple(H0):
+    inv = 1 / H0
+    mpc_over_km = u.Mpc.to(u.km)
+    s_to_gyr = u.s.to(u.Gyr)
+    return round(inv * mpc_over_km * s_to_gyr, 1)
+
 
 def format_fov(fov):
     return fov.to_string(unit=u.degree, sep=":", precision=0, pad=True) + " (dd:mm:ss)"

--- a/cosmicds/stories/hubbles_law/viewers/__init__.py
+++ b/cosmicds/stories/hubbles_law/viewers/__init__.py
@@ -1,2 +1,2 @@
-from .fit_view import *
 from .spectrum_view import *
+from .viewers import *

--- a/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
+++ b/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
@@ -37,7 +37,7 @@ class SpectrumView(BqplotScatterView):
     _subset_artist_cls = SpectrumViewLayerArtist
 
     inherit_tools = False
-    tools = ['bqplot:home', 'bqplot:xzoom', 'hubble:restwave', 'cds:info']
+    tools = ['bqplot:home', 'hubble:wavezoom', 'hubble:restwave', 'cds:info']
     _state_cls = SpectrumViewerState
     show_line = Bool(True)
     LABEL = "Spectrum Viewer"
@@ -106,7 +106,7 @@ class SpectrumView(BqplotScatterView):
 
     def _active_tool_change(self, change):
         is_tool = change.new is not None
-        line_visible = not is_tool or change.new.tool_id != 'bqplot:xzoom'
+        line_visible = not is_tool or change.new.tool_id != 'hubble:wavezoom'
         self.user_line.visible = line_visible
         self.user_line_label.visible = line_visible
 

--- a/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
+++ b/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
@@ -145,6 +145,11 @@ class SpectrumView(BqplotScatterView):
         self.z = z
         rest = MG_REST_LAMBDA if element == 'Mg-I' else H_ALPHA_REST_LAMBDA
         self.shifted = rest * (1 + z)
+        items_visible = bool(z > 0) # The bqplot Mark complained without the explicit bool() call
+        self.element_label.visible = items_visible
+        self.element_tick.visible = items_visible
+        self.user_line.visible = items_visible
+        self.user_line_label.visible = items_visible
         self.element_label.x = [self.shifted, self.shifted]
         self.element_label.text = [element]
         self.element_tick.x = [self.shifted, self.shifted]

--- a/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
+++ b/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
@@ -37,7 +37,7 @@ class SpectrumView(BqplotScatterView):
     _subset_artist_cls = SpectrumViewLayerArtist
 
     inherit_tools = False
-    tools = ['bqplot:home', 'hubble:wavezoom', 'hubble:restwave', 'cds:info']
+    tools = ['bqplot:home', 'hubble:wavezoom', 'hubble:restwave', 'hubble:specflag', 'cds:info']
     _state_cls = SpectrumViewerState
     show_line = Bool(True)
     LABEL = "Spectrum Viewer"
@@ -139,7 +139,8 @@ class SpectrumView(BqplotScatterView):
         self.user_line.x = [new_x, new_x]
         self.user_line_label.x = [new_x, new_x]
 
-    def update(self, element, z):
+    def update(self, name, element, z):
+        self.spectrum_name = name
         self.element = element
         self.z = z
         rest = MG_REST_LAMBDA if element == 'Mg-I' else H_ALPHA_REST_LAMBDA

--- a/cosmicds/stories/hubbles_law/viewers/viewers.py
+++ b/cosmicds/stories/hubbles_law/viewers/viewers.py
@@ -1,0 +1,73 @@
+from echo import delay_callback
+from glue.viewers.scatter.state import ScatterViewerState
+from glue_jupyter.bqplot.histogram import BqplotHistogramView
+from glue_jupyter.bqplot.scatter import BqplotScatterView
+from cosmicds.viewers import cds_viewer
+
+__all__ = [
+    "HubbleScatterViewerState","HubbleFitViewerState", 
+    "HubbleFitView", "HubbleScatterView", "HubbleClassHistogramView"
+]
+
+class HubbleScatterViewerState(ScatterViewerState):
+
+    def reset_limits(self):
+        with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
+            super().reset_limits()
+            self.x_min = min(self.x_min, 0)
+            self.y_min = min(self.y_min, 0)
+
+class HubbleFitViewerState(HubbleScatterViewerState):
+
+    def reset_limits(self):
+        with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
+            super().reset_limits()
+            self.x_max = 1.2 * self.x_max
+            self.y_max = 1.2 * self.y_max
+
+HubbleFitView = cds_viewer(
+    BqplotScatterView,
+    name="HubbleFitView",
+    viewer_tools=[
+        "bqplot:home",
+        "bqplot:rectzoom",
+        "bqplot:rectangle",
+        "cds:linedraw",
+        "cds:linefit"
+    ],
+    label='Fit View',
+    state_cls=HubbleFitViewerState
+)
+
+HubbleScatterView = cds_viewer(
+    BqplotScatterView,
+    name="HubbleScatterView",
+    viewer_tools=[
+        'bqplot:home',
+        'bqplot:rectzoom',
+        'cds:linefit'
+    ],
+    label='Scatter View',
+    state_cls=HubbleScatterViewerState
+)
+
+HubbleHistogramView = cds_viewer(
+    BqplotHistogramView,
+    name="HubbleHistogramView",
+    viewer_tools=[
+        "bqplot:home",
+        "bqplot:xzoom",
+    ],
+    label="Class Histogram"
+)
+
+HubbleClassHistogramView = cds_viewer(
+    BqplotHistogramView,
+    name="HubbleClassHistogramView",
+    viewer_tools=[
+        "bqplot:home",
+        "bqplot:xzoom",
+        "bqplot:xrange"
+    ],
+    label="Class Histogram"
+)

--- a/cosmicds/tools/line_fit_tool.py
+++ b/cosmicds/tools/line_fit_tool.py
@@ -61,8 +61,9 @@ class LineFitTool(Tool, HubListener):
         start_x, end_x = x
         start_y, end_y = y
         slope = fitted_line.slope.value
-        label = 'Slope = %.0f ks / s / Mpc' % slope if not isnan(slope) else None
-        line = line_mark(layer, start_x, start_y, end_x, end_y, layer.state.color, label)
+        label = 'Slope = %.0f km / s / Mpc' % slope if not isnan(slope) else None
+        color = layer.state.color if layer.state.color != '0.35' else 'black'
+        line = line_mark(layer, start_x, start_y, end_x, end_y, color, label)
         return line, slope
 
     def activate(self):
@@ -84,7 +85,7 @@ class LineFitTool(Tool, HubListener):
             self.lines[label] = line
             self.slopes[label] = slope
 
-        figure.marks = [marks_to_keep] + list(self.lines.keys())
+        figure.marks = marks_to_keep + list(self.line_marks)
 
 
     def _clear_lines(self):
@@ -92,6 +93,10 @@ class LineFitTool(Tool, HubListener):
         figure.marks = [mark for mark in figure.marks if mark not in self.lines.keys()]
         self.lines = {}
         self.slopes = {}
+
+    @property
+    def line_marks(self):
+        return self.lines.values()
             
             
 

--- a/cosmicds/tools/line_fit_tool.py
+++ b/cosmicds/tools/line_fit_tool.py
@@ -7,7 +7,7 @@ from glue.core.message import (DataCollectionAddMessage,
 from glue_jupyter.bqplot.common.tools import Tool
 from numpy import isnan
 
-from cosmicds.stories.hubbles_law.utils import line_mark
+from cosmicds.stories.hubbles_law.utils import line_mark, age_in_gyr_simple
 
 @viewer_tool
 class LineFitTool(Tool, HubListener):
@@ -61,7 +61,8 @@ class LineFitTool(Tool, HubListener):
         start_x, end_x = x
         start_y, end_y = y
         slope = fitted_line.slope.value
-        label = 'Slope = %.0f km / s / Mpc' % slope if not isnan(slope) else None
+        age = age_in_gyr_simple(slope)
+        label = 'H0 = %.0f km/s/Mpc; %.1f Gyr' % (slope, age) if not isnan(slope) else None
         color = layer.state.color if layer.state.color != '0.35' else 'black'
         line = line_mark(layer, start_x, start_y, end_x, end_y, color, label)
         return line, slope

--- a/cosmicds/tools/line_fit_tool.py
+++ b/cosmicds/tools/line_fit_tool.py
@@ -75,7 +75,7 @@ class LineFitTool(Tool, HubListener):
     def _fit_to_layers(self):
 
         figure = self.viewer.figure
-        marks_to_keep = [mark for mark in figure.marks if mark not in self.lines.keys()]
+        marks_to_keep = [mark for mark in figure.marks if mark not in self.line_marks]
 
         self.lines = {}
         self.slopes = {}
@@ -90,7 +90,7 @@ class LineFitTool(Tool, HubListener):
 
     def _clear_lines(self):
         figure = self.viewer.figure
-        figure.marks = [mark for mark in figure.marks if mark not in self.lines.keys()]
+        figure.marks = [mark for mark in figure.marks if mark not in self.line_marks]
         self.lines = {}
         self.slopes = {}
 

--- a/cosmicds/viewers/cds_viewers.py
+++ b/cosmicds/viewers/cds_viewers.py
@@ -7,12 +7,19 @@ from glue_jupyter.bqplot.histogram import BqplotHistogramView
 
 from cosmicds.components.toolbar import Toolbar
 
-def cds_viewer(viewer_class, viewer_tools, label=None):
+def cds_viewer(viewer_class, name=None, viewer_tools=None, label=None, state_cls=None):
     class CDSViewer(viewer_class):
 
-        inherit_tools = False
-        tools = viewer_tools
+        __name__ = name
+        __qualname__ = name
+        _state_cls = state_cls or viewer_class._state_cls
+        inherit_tools = viewer_tools is None
+        tools = viewer_tools or viewer_class.tools
         LABEL = label or viewer_class.LABEL
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.ignore_conditions = []
 
         def initialize_toolbar(self):
             self.toolbar = Toolbar(self)
@@ -21,9 +28,41 @@ def cds_viewer(viewer_class, viewer_tools, label=None):
                 mode_cls = viewer_tool.members[tool_id]
                 mode = mode_cls(self)
                 self.toolbar.add_tool(mode)
+
+        def ignore(self, condition):
+            self.ignore_conditions.append(condition)
+
+        def add_data(self, data):
+            if any(condition(data) for condition in self.ignore_conditions):
+                return False
+            return super().add_data(data)
+
+        def add_subset(self, subset):
+            if any(condition(subset) for condition in self.ignore_conditions):
+                return False
+            return super().add_subset(subset)
         
     return CDSViewer
 
 
-CDSScatterView = cds_viewer(BqplotScatterView, ['bqplot:home', 'bqplot:rectzoom', 'bqplot:rectangle'], '2D scatter')
-CDSHistogramView = cds_viewer(BqplotHistogramView, ['bqplot:home', 'bqplot:xzoom', 'bqplot:xrange'], 'Histogram')
+CDSScatterView = cds_viewer(
+    BqplotScatterView,
+    name='CDSScatterView',
+    viewer_tools=[
+        'bqplot:home',
+        'bqplot:rectzoom',
+        'bqplot:rectangle'
+    ],
+    label='2D scatter'
+)
+
+CDSHistogramView = cds_viewer(
+    BqplotHistogramView,
+    name='CDSHistogramView',
+    viewer_tools=[
+        'bqplot:home',
+        'bqplot:xzoom',
+        'bqplot:xrange'
+    ],
+    label='Histogram'
+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,10 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 include_package_data = True
 install_requires = 
+  numpy <= 1.22
   glue-core
   glue-jupyter
-  glue-wwt
+  pywwt @ git+https://github.com/Carifio24/pywwt@prekdr
   pyqt5
   PyQtWebEngine
   qtpy
@@ -27,11 +28,10 @@ install_requires =
   bqplot-image-gl
   ipyvue
   ipyvuetify
-  voila @ git+https://github.com/nmearl/voila
+  voila @ git+https://github.com/Carifio24/voila@prekdr
   echo
   click
   pymongo
-  wwt_kernel_data_relay
 
 [options.extras_require]
 all =


### PR DESCRIPTION
@Carifio24, this is the start of the offshoot branch that team members can use to quickly generate "seed" student data.

Still needed
- ~~Addition of a field for team members to tag their measurements with their name, in case we need to sort out later who submitted which data points.~~
- ~~Wire up the Stage 2 distance measuring tool as follows:~~
  --  ~~Add "angular size" column to table.~~
  --  ~~When student makes measurement, the angular size and distance should autofill into the table (and update when the measurement is adjusted.)  No additional button click should be needed to calculate the distance (as real students will do).~~
- ~~A "start over" button on the Stage 2 page can be clicked when the measurements are complete. That should clear all the data and create a fresh slate for a new round of measurements with a new dummy student ID tag.~~

Let me know if you have questions. Thanks so much!