### PR TITLE
Spectrum flagger branch

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -29,7 +29,7 @@ class Application(VuetifyTemplate, HubListener):
     _metadata = Dict({"mount_id": "content"}).tag(sync=True)
     story_state = GlueState().tag(sync=True)
     template = load_template("app.vue", __file__, traitlet=True).tag(sync=True)
-    drawer = Bool(True).tag(sync=True)
+    drawer = Bool(False).tag(sync=True)
     vue_components = Dict().tag(sync=True, **widget_serialization)
     app_state = GlueState().tag(sync=True)
 

--- a/cosmicds/stories/hubbles_law/stages/__init__.py
+++ b/cosmicds/stories/hubbles_law/stages/__init__.py
@@ -1,4 +1,1 @@
-from .stage_intro import *
 from .stage_one import *
-from .stage_two import *
-from .stage_three import *

--- a/cosmicds/stories/hubbles_law/stages/stage_one.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.vue
@@ -1,113 +1,8 @@
 <template>
   <v-container>
-    <v-row v-if="show_team_interface">
-      <v-col>
-        <v-btn
-          color="error"
-          class="black--text"
-          @click="fill_data();"
-        >fill data points</v-btn>
-        <v-btn
-          @click="console.log(stage_state)"
-        >
-          State
-        </v-btn>
-      </v-col>
-    </v-row>
-
     <v-row>
       <v-col
-        cols="12"
-        lg="4"
-      >
-        <c-stage-one-start-guidance
-          v-if="stage_state.marker == 'mee_gui1'" />
-        <c-select-galaxies-alert
-          v-if="stage_state.marker == 'sel_gal1'" />
-        <c-select-galaxies-2-guidance
-          v-if="stage_state.marker == 'sel_gal2'" />
-        <v-btn
-          v-if="stage_state.marker == 'sel_gal2' && stage_state.gals_total < stage_state.gals_max && show_team_interface"
-          color="error"
-          class="black--text"
-          block
-          @click="select_galaxies();"
-        >select 5 galaxies</v-btn>
-      </v-col>
-      <v-col
-        cols="12"
-        lg="8"
-      >
-        <v-card
-          :color="stage_state.marker == 'sel_gal1' || stage_state.marker == 'sel_gal2' ? 'info' : 'black'"
-          :class="stage_state.marker == 'sel_gal1' || stage_state.marker == 'sel_gal2' ? 'pa-1 my-n1' : 'pa-0'"
-          outlined
-        >
-          <c-selection-tool/>
-          <!-- <v-card-actions>
-            <v-btn @click="story_state.step_index += 1; story_state.step_complete = true">Next Step</v-btn>
-          </v-card-actions> -->
-        </v-card>
-      </v-col>
-    </v-row>
-    <v-row>
-      <v-col
-        cols="12"
-        lg="4"
-      >
-        <c-choose-row-guidance
-          v-if="stage_state.marker == 'cho_row1'" />
-        <c-doppler-calc-3-guidance
-          v-if="stage_state.marker == 'dop_cal3'" /> 
-        <c-doppler-calc-4-component
-          v-if="stage_state.marker == 'dop_cal4' || stage_state.marker == 'dop_cal5'"/>
-        <c-doppler-calc-5-slideshow
-          v-if="stage_state.marker == 'dop_cal5'"/>
-        <c-doppler-calc-6-component
-          v-if="stage_state.marker == 'dop_cal6'"/> 
-          
-      </v-col>
-      <v-col
-        cols="12"
-        lg="8"
-        class="galtable_column"
-      >
-        <v-card
-          :color="stage_state.marker == 'cho_row1' ? 'info' : 'black'"
-          :class="stage_state.marker == 'cho_row1' ? 'pa-1 my-n1' : 'pa-0'"
-          outlined
-        >
-          <jupyter-widget :widget="widgets.galaxy_table"/>
-        </v-card>
-      </v-col>
-    </v-row>
-    <v-row>
-      <v-col
-        cols="12"
-        lg="4"
-      >
-        <c-spectrum-guidance 
-          v-if="stage_state.marker == 'mee_spe1'"/>
-        <c-restwave-guidance
-          v-if="stage_state.marker == 'res_wav1'" />
-        <c-obswave-1-guidance
-          v-if="stage_state.marker == 'obs_wav1'" />
-        <c-obswave-2-alert
-          v-if="stage_state.marker == 'obs_wav2'" />
-        <c-remaining-gals-alert
-          v-if="stage_state.marker == 'rep_rem1'" />
-        <c-nice-work-guidance
-          v-if="stage_state.marker == 'nic_wor1'" />
-        <c-doppler-calc-0-alert
-          v-if="stage_state.marker == 'dop_cal0'" />
-        <c-doppler-calc-1-alert
-          v-if="stage_state.marker == 'dop_cal1'" />
-        <c-doppler-calc-2-alert
-          v-if="stage_state.marker == 'dop_cal2'" />            
-      </v-col>
-      <v-col
-        v-if="stage_state.indices[stage_state.marker] >= stage_state.indices['mee_spe1']"
-        cols="12"
+        cols="10"
         lg="8"
       >
         <v-row>
@@ -119,50 +14,57 @@
               :class="stage_state.indices[stage_state.marker] >= stage_state.indices['mee_spe1'] ? 'pa-1 my-n1' : 'pa-0'"
               outlined
             >
+              <v-card-title>{{spectrum_name}}</v-card-title>
               <jupyter-widget :widget="viewers.spectrum_viewer"/>
 
             </v-card>
           </v-col>
         </v-row>
+      </v-col>
+      <v-col cols="2">
         <v-row>
-          <v-col
-            cols="3"
+          <v-btn
+            icon
+            large
+            @click="stage_state.galaxy_index = stage_state.galaxy_index - 1"
           >
-            <!-- FORM DIALOG as template for reflections/MC -->
-            <c-spectrum-slideshow v-if="stage_state.indices[stage_state.marker] >= stage_state.indices['mee_spe1']" />
-          </v-col>
-          <v-col
-            cols="3"
+            <v-icon>mdi-chevron-left</v-icon>
+          </v-btn>
+          <v-btn
+            icon
+            large
+            @click="stage_state.galaxy_index = stage_state.galaxy_index + 1"
           >
-            <!-- FORM DIALOG as template for reflections/MC -->
-            <reflect-velocity-windows
-              v-if="stage_state.waveline_set"
-              button-text="reflect"
-              close-text="submit"
-              @submit="
-                stage_state.reflection_complete = true;
-                console.log('Submit button was clicked.');
-              "
-            >
-            </reflect-velocity-windows>
-          </v-col>
-          <v-col
-            cols="6"
+            <v-icon>mdi-chevron-right</v-icon>
+          </v-btn>
+        </v-row>
+        <v-row>
+          <v-btn
+            color="green"
+            @click="() => {
+              send_spectrum_status({
+                name: spectrum_name,
+                good: true
+              });
+              stage_state.galaxy_index = stage_state.galaxy_index + 1
+            }"
           >
-            <!-- This alert is temporary -->
-            <v-btn
-              v-if="show_team_interface"
-              :disabled="!stage_state.waveline_set"
-              class="white-text px-a"
-              width="100%"
-              color="success"
-              @click="
-                add_current_velocity();
-              "
-            >
-              find velocity
-            </v-btn>
-          </v-col>
+            Good
+          </v-btn>
+        </v-row>
+        <v-row>
+          <v-btn
+            color="red"
+            @click="() => {
+              send_spectrum_status({
+                name: spectrum_name,
+                good: false
+              });
+              stage_state.galaxy_index = stage_state.galaxy_index + 1
+            }"
+          >
+            Bad
+          </v-btn>
         </v-row>
       </v-col>
     </v-row>

--- a/cosmicds/stories/hubbles_law/state.py
+++ b/cosmicds/stories/hubbles_law/state.py
@@ -73,7 +73,7 @@ class HubblesLaw(Story):
         ])
 
         # Load in the galaxy data
-        galaxies = requests.get(f"{API_URL}/{HUBBLE_ROUTE_PATH}/galaxies").json()
+        galaxies = requests.get(f"{API_URL}/{HUBBLE_ROUTE_PATH}/unchecked-galaxies").json()
         galaxies_dict = { k : [x[k] for x in galaxies] for k in galaxies[0] }
         name_ext = ".fits"
         galaxies_dict["name"] = [x[:-len(name_ext)] for x in galaxies_dict["name"]]

--- a/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
+++ b/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
@@ -35,7 +35,7 @@ class SpectrumView(BqplotScatterView):
     _subset_artist_cls = SpectrumViewLayerArtist
 
     inherit_tools = False
-    tools = ['bqplot:home', 'hubble:wavezoom', 'hubble:restwave', 'hubble:specflag', 'cds:info']
+    tools = ['bqplot:home', 'hubble:wavezoom', 'hubble:restwave', 'cds:info']
     _state_cls = SpectrumViewerState
     show_line = Bool(True)
     LABEL = "Spectrum Viewer"


### PR DESCRIPTION
This PR contains the spectrum flagger branch, which is specifically for our internal use to check spectra. Pretty much everything except the spectrum viewer has been stripped out. The spectrum viewer will cycle through unchecked galaxies.

As each spectrum appears, one can mark it as "good" or "bad" using the two buttons. These two buttons will send requests that directly update the `spec_is_good` and `spec_is_bad` fields in the galaxy table of the database. When you mark a galaxy, the next one will pop up. If you make a mistake, you can use the arrow buttons to go back and fix it.

This branch is pulling galaxies from a different endpoint than the regular app  (`/hubbles_law/unchecked-galaxies` rather than `hubbles_law/galaxies`). Thus, if you close the app and re-open it, galaxies that have already been checked won't appear in the list.