### PR TITLE
Use pre-KDR version of pywwt

### DIFF
--- a/cosmicds/__init__.py
+++ b/cosmicds/__init__.py
@@ -17,11 +17,3 @@ for comp_path in vue_comp_dir.iterdir():
 
 from .stories import *
 from .tools import *
-
-# Monkey-patch pywwt kernel connection function
-from pywwt import jupyter_relay
-
-def _override_compute_notebook_server_base_url():
-    return "/api/kernels/"
-
-jupyter_relay._compute_notebook_server_base_url = _override_compute_notebook_server_base_url

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,10 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 include_package_data = True
 install_requires = 
+  numpy <= 1.22
   glue-core
   glue-jupyter
-  glue-wwt
+  pywwt @ git+https://github.com/Carifio24/pywwt@prekdr
   pyqt5
   PyQtWebEngine
   qtpy
@@ -27,11 +28,10 @@ install_requires =
   bqplot-image-gl
   ipyvue
   ipyvuetify
-  voila @ git+https://github.com/nmearl/voila
+  voila @ git+https://github.com/Carifio24/voila@prekdr
   echo
   click
   pymongo
-  wwt_kernel_data_relay
 
 [options.extras_require]
 all =


### PR DESCRIPTION
This PR modifies the app to use a pre-KDR version of pywwt, since that seems to be the source of a lot of our pywwt loading issues. This is accomplished by getting pywwt from my `prekdr` branch, which is primarily a rewound version of pywwt (with one commit on top of that to grab the newest research app version). I also had to make a tweak to our hacked voila version, so this PR is also pulling voila from one of my branches (which is one commit ahead of Nick's branch that we're currently using). Assuming this works for everyone, we can merge these changes into Nick's voila branch if we want to.

On my end, this is working great in both the Jupyter notebook and voila, but I'm curious to see how this works for everyone else.