### PR TITLE
Allow enabling/disabling of tool buttons

### DIFF
--- a/cosmicds/components/toolbar/toolbar.py
+++ b/cosmicds/components/toolbar/toolbar.py
@@ -88,6 +88,9 @@ class Toolbar(VuetifyTemplate):
         tool = self.tools[tool_id]
         self.update_tools_data(tool, { "disabled": not enabled })
 
+    def is_tool_enabled(self, tool_id):
+        return not self.tools_data[tool_id]["disabled"]
+
     def add_tool(self, tool, data={}):
         self.tools[tool.tool_id] = tool
         self.update_tools_data(tool, data)

--- a/cosmicds/components/toolbar/toolbar.py
+++ b/cosmicds/components/toolbar/toolbar.py
@@ -17,6 +17,8 @@ class Toolbar(VuetifyTemplate):
         'bqplot:rectangle': 'mdi-select-drag',
     }
 
+    _TOOL_TRAITS = ["tool_tip"]
+
     template = load_template("toolbar.vue", __file__, traitlet=True).tag(sync=True)
     active_tool = Instance(Tool, allow_none=True,
                                      default_value=None)
@@ -68,22 +70,30 @@ class Toolbar(VuetifyTemplate):
             icon = cls.TOOL_ICONS.get(tool.tool_id, "")
         return icon
 
-    def update_tools_data(self, tool):
+    def update_tools_data(self, tool, data={}):
         self.tools_data = {
             **self.tools_data, 
             tool.tool_id: {
                 "tooltip" : tool.tool_tip,
-                "icon": Toolbar.get_icon(tool)
+                "icon": Toolbar.get_icon(tool),
+                "disabled": False,
+                **data
             }
         }
 
     def refresh_tools_data(self, change):
         self.update_tools_data(change["owner"])
 
-    def add_tool(self, tool):
-        self.tools[tool.tool_id] = tool
-        self.update_tools_data(tool)
+    def set_tool_enabled(self, tool_id, enabled):
+        tool = self.tools[tool_id]
+        self.update_tools_data(tool, { "disabled": not enabled })
 
-        if isinstance(tool, HasTraits) and "tool_tip" in tool.traits():
-            tool.observe(self.refresh_tools_data, names=["tool_tip"])
+    def add_tool(self, tool, data={}):
+        self.tools[tool.tool_id] = tool
+        self.update_tools_data(tool, data)
+
+        if isinstance(tool, HasTraits):
+            for trait in self._TOOL_TRAITS:
+                if trait in tool.traits():
+                    tool.observe(self.refresh_tools_data, names=[trait])
 

--- a/cosmicds/components/toolbar/toolbar.vue
+++ b/cosmicds/components/toolbar/toolbar.vue
@@ -1,19 +1,24 @@
 <template>
-    <v-btn-toggle
-        v-model="active_tool_id"
-        borderless
-        class="transparent"
+  <v-btn-toggle
+    v-model="active_tool_id"
+    borderless
+    class="transparent"
+    >
+    <v-tooltip
+      v-for="[id, {tooltip, icon, disabled}] of Object.entries(tools_data)"
+      :key="id"
+      top>
+      <template v-slot:activator="{ on }">
+        <v-btn
+          v-on="on"
+          icon
+          :value="id"
+          :disabled="disabled"
         >
-        <v-tooltip
-            v-for="[id, {tooltip, icon}] of Object.entries(tools_data)"
-            :key="id"
-            top>
-            <template v-slot:activator="{ on }">
-                <v-btn v-on="on" icon :value="id">
-                    <v-icon>{{ icon }}</v-icon>
-                </v-btn>
-            </template>
-            <span>{{ tooltip }}</span>
-        </v-tooltip>
-    </v-btn-toggle>
+          <v-icon>{{ icon }}</v-icon>
+        </v-btn>
+      </template>
+      <span>{{ tooltip }}</span>
+    </v-tooltip>
+  </v-btn-toggle>
 </template>

--- a/cosmicds/stories/hubbles_law/stages/stage_one.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.py
@@ -267,6 +267,9 @@ class StageOne(HubbleStage):
 
         spectrum_viewer = self.get_viewer("spectrum_viewer")
         restwave_tool = spectrum_viewer.toolbar.tools["hubble:restwave"]
+        spectrum_viewer.toolbar.set_tool_enabled("hubble:restwave", False)
+        spectrum_viewer.toolbar.set_tool_enabled("hubble:wavezoom", False)        
+        spectrum_viewer.toolbar.set_tool_enabled("bqplot:home", False)    
 
         add_callback(restwave_tool, 'lambda_used', self._on_lambda_used)
         add_callback(restwave_tool, 'lambda_on', self._on_lambda_on)
@@ -288,6 +291,16 @@ class StageOne(HubbleStage):
         if advancing and old == "dop_cal2":
             self.galaxy_table.selected = []
             self.selection_tool.widget.center_on_coordinates(self.START_COORDINATES, instant=True)
+        if advancing and new == "res_wav1":
+            spectrum_viewer = self.get_viewer("spectrum_viewer") 
+            if spectrum_viewer.toolbar.is_tool_enabled("hubble:restwave")==False:
+                spectrum_viewer.toolbar.set_tool_enabled("hubble:restwave", True)
+        if advancing and new == "obs_wav2":
+            spectrum_viewer = self.get_viewer("spectrum_viewer") 
+            if spectrum_viewer.toolbar.is_tool_enabled("hubble:wavezoom")==False:
+                spectrum_viewer.toolbar.set_tool_enabled("hubble:wavezoom", True)
+            if spectrum_viewer.toolbar.is_tool_enabled("bqplot:home")==False:
+                spectrum_viewer.toolbar.set_tool_enabled("bqplot:home", True)
 
     def _on_step_index_update(self, index):
         # Change the marker without firing the associated stage callback

--- a/cosmicds/stories/hubbles_law/stages/stage_one.py
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.py
@@ -267,12 +267,10 @@ class StageOne(HubbleStage):
 
         spectrum_viewer = self.get_viewer("spectrum_viewer")
         restwave_tool = spectrum_viewer.toolbar.tools["hubble:restwave"]
-        spectrum_viewer.toolbar.set_tool_enabled("hubble:restwave", False)
-        spectrum_viewer.toolbar.set_tool_enabled("hubble:wavezoom", False)        
-        spectrum_viewer.toolbar.set_tool_enabled("bqplot:home", False)    
-
         add_callback(restwave_tool, 'lambda_used', self._on_lambda_used)
         add_callback(restwave_tool, 'lambda_on', self._on_lambda_on)
+        for tool_id in ["hubble:restwave", "hubble:wavezoom", "bqplot:home"]:
+            spectrum_viewer.toolbar.set_tool_enabled(tool_id, False)
 
     def _on_marker_update(self, old, new):
         if not self.trigger_marker_update_cb:
@@ -292,15 +290,12 @@ class StageOne(HubbleStage):
             self.galaxy_table.selected = []
             self.selection_tool.widget.center_on_coordinates(self.START_COORDINATES, instant=True)
         if advancing and new == "res_wav1":
-            spectrum_viewer = self.get_viewer("spectrum_viewer") 
-            if spectrum_viewer.toolbar.is_tool_enabled("hubble:restwave")==False:
-                spectrum_viewer.toolbar.set_tool_enabled("hubble:restwave", True)
+            spectrum_viewer = self.get_viewer("spectrum_viewer")
+            spectrum_viewer.toolbar.set_tool_enabled("hubble:restwave", True)
         if advancing and new == "obs_wav2":
-            spectrum_viewer = self.get_viewer("spectrum_viewer") 
-            if spectrum_viewer.toolbar.is_tool_enabled("hubble:wavezoom")==False:
-                spectrum_viewer.toolbar.set_tool_enabled("hubble:wavezoom", True)
-            if spectrum_viewer.toolbar.is_tool_enabled("bqplot:home")==False:
-                spectrum_viewer.toolbar.set_tool_enabled("bqplot:home", True)
+            spectrum_viewer = self.get_viewer("spectrum_viewer")
+            spectrum_viewer.toolbar.set_tool_enabled("hubble:wavezoom", True)
+            spectrum_viewer.toolbar.set_tool_enabled("bqplot:home", True)
 
     def _on_step_index_update(self, index):
         # Change the marker without firing the associated stage callback

--- a/cosmicds/stories/hubbles_law/stages/stage_one.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_one.vue
@@ -8,7 +8,10 @@
           @click="fill_data();"
         >fill data points</v-btn>
         <v-btn
-          @click="console.log(stage_state)"
+          @click="() => {
+            console.log('stage state:', stage_state);
+            console.log('story state:', story_state);
+            }"
         >
           State
         </v-btn>

--- a/cosmicds/stories/hubbles_law/stages/stage_two.vue
+++ b/cosmicds/stories/hubbles_law/stages/stage_two.vue
@@ -3,7 +3,10 @@
     <v-row v-if="show_team_interface">
       <v-col>
         <v-btn
-          @click="console.log(stage_state)"
+          @click="() => {
+            console.log('stage state:', stage_state);
+            console.log('story state:', story_state);
+            }"
         >
           State
         </v-btn>


### PR DESCRIPTION
This PR adds functionality to our glue toolbar to allow enabling/disabling of tools (e.g. when a student reaches a certain point in the story). This is done by adding a `disabled` field to each tool's entry in the toolbar's `tools_data`, which we can then update in the appropriate way so that `ipyvuetify` responds to the change. To facilitate these updates, I've added `set_tool_enabled` and `is_tool_enabled` methods to the toolbar, which both identify tools by their IDs. For example, to disable the rest wavelength tool on the spectrum viewer in stage one, you would do

```
spectrum_viewer.toolbar.set_tool_enabled("hubble:restwave", False)
```

Calling `spectrum_viewer.toolbar.is_tool_enabled("hubble:restwave")` will return whether the tool is currently enabled or not.