### PR TITLE
Spectrum viewer updates, part 2

### DIFF
--- a/cosmicds/stories/hubbles_law/CosmicDS.ipynb
+++ b/cosmicds/stories/hubbles_law/CosmicDS.ipynb
@@ -36,7 +36,7 @@
     "\n",
     "from cosmicds.app import Application\n",
     "\n",
-    "app = Application(story='hubbles_law', update_db=True)\n",
+    "app = Application(story='hubbles_law', update_db=False)\n",
     "app"
    ]
   },

--- a/cosmicds/stories/hubbles_law/tools/rest_wavelength_tool.py
+++ b/cosmicds/stories/hubbles_law/tools/rest_wavelength_tool.py
@@ -78,5 +78,5 @@ class RestWavelengthTool(CheckableTool):
         ymin, ymax = scale.min, scale.max
         if ymin is None or ymax is None:
             return
-        self.line.y = [ymin, ymax * 0.93]
-        self.label.y = [ymax * 0.96]
+        self.line.y = [ymin, ymax * 0.95]
+        self.label.y = [ymax * 0.99]

--- a/cosmicds/stories/hubbles_law/tools/wavelength_zoom.py
+++ b/cosmicds/stories/hubbles_law/tools/wavelength_zoom.py
@@ -1,5 +1,6 @@
 from cosmicds.tools import BqplotXZoom
 from glue.config import viewer_tool
+from cosmicds.stories.hubbles_law.viewers import SpectrumViewerState
 
 
 @viewer_tool #this decorator tells glue this is a viewer tool so it knows what to do with all this info
@@ -11,9 +12,16 @@ class WavelengthZoom(BqplotXZoom):
     action_text = 'x axis zoom'
     tool_tip = 'Zoom in on a region of the x-axis'
 
+    on_zoom = None
+
     def update_selection(self, *args):
+        old_state = SpectrumViewerState()
+        old_state.update_from_state(self.viewer.state)
         if self.interact.brushing:
             return
         super().update_selection(*args)
+
+        if self.on_zoom is not None:
+            self.on_zoom(old_state, self.viewer.state)
 
         self.deactivate()

--- a/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
+++ b/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
@@ -34,6 +34,7 @@ class SpectrumViewLayerArtist(BqplotScatterLayerArtist):
         old_scatter = self.scatter
         self.scatter = Lines(scales=self.scales, x=[0,1], y=[0,1], marker=None)
         self.view.figure.marks = list(filter(lambda x: x is not old_scatter, self.view.figure.marks)) + [self.scatter]
+        self.scatter.colors = ['#507FB6']
         
 class SpectrumView(BqplotScatterView):
 
@@ -62,7 +63,22 @@ class SpectrumView(BqplotScatterView):
             scales={
                 'x': self.scales['x'],
                 'y': self.scales['y'],
-            })
+            },
+            colors=['#1b3e6a'],
+        )
+
+        self.user_line_label = Label(
+            text=[""], 
+            x=[], 
+            y=[],
+            x_offset=10,
+            y_offset=10,
+            scales={
+                'x': self.scales['x'],
+                'y': self.scales['y'],
+            },
+            colors=['#1b3e6a'],
+        )
 
         self.label_background = Lines(
             x=[0, 0],
@@ -73,19 +89,8 @@ class SpectrumView(BqplotScatterView):
                 'y': self.scales['y'],
             },
             colors=['white'],
-            opacities=[0.7]
+            opacities=[0.8]
         )
-        
-        self.user_line_label = Label(
-            text=[""], 
-            x=[], 
-            y=[],
-            x_offset=10,
-            y_offset=10,
-            scales={
-                'x': self.scales['x'],
-                'y': self.scales['y'],
-            })
 
         self.previous_line = Lines(
             x=[0, 0],
@@ -108,7 +113,7 @@ class SpectrumView(BqplotScatterView):
                 'x': self.scales['x'],
                 'y': self.scales['y'],
             },
-            colors=['gray'],
+            colors=['#4c4a4a'],
             visible=False
         )
 
@@ -121,7 +126,7 @@ class SpectrumView(BqplotScatterView):
                 'y': self.scales['y'],
             },
             colors=['white'],
-            opacities=[0.7]
+            opacities=[0.8]
         )
 
         self.element_tick = Lines(

--- a/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
+++ b/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
@@ -186,8 +186,7 @@ class SpectrumView(BqplotScatterView):
     def _active_tool_change(self, change):
         is_tool = change.new is not None
         line_visible = not is_tool or change.new.tool_id != 'hubble:wavezoom'
-        for mark in [self.user_line, self.user_line_label, self.label_background,
-                     self.previous_line, self.previous_line_label, self.previous_label_background]:
+        for mark in [self.user_line, self.user_line_label, self.label_background]:
             mark.visible = line_visible
 
     def _on_ymin_change(self, old, new):

--- a/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
+++ b/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
@@ -2,7 +2,7 @@ from glue.viewers.scatter.state import ScatterViewerState
 from glue_jupyter.bqplot.scatter import BqplotScatterView, BqplotScatterLayerArtist
 from bqplot.marks import Lines
 from bqplot import Label
-from echo import add_callback, delay_callback
+from echo import add_callback, delay_callback, CallbackProperty
 from glue.config import viewer_tool
 from glue.viewers.common.utils import get_viewer_tools
 from traitlets import Bool
@@ -17,14 +17,21 @@ class SpectrumViewerState(ScatterViewerState):
 
     _YMAX_FACTOR = 1.5
 
+    resolution_x = CallbackProperty(0)
+    resolution_y = CallbackProperty(0)
+
     @property
     def ymax_factor(self):
         return self._YMAX_FACTOR
 
     def reset_limits(self):
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
+            xmin, xmax = self.x_min, self.x_max
+            ymin, ymax = self.y_min, self.y_max
             super().reset_limits()
             self.y_max = self._YMAX_FACTOR * self.y_max
+            self.resolution_x *= (self.x_max - self.x_min) / (xmax - xmin)
+            self.resolution_y *= (self.y_max - self.y_min) / (ymax - ymin)
 
 
 class SpectrumViewLayerArtist(BqplotScatterLayerArtist):
@@ -32,9 +39,8 @@ class SpectrumViewLayerArtist(BqplotScatterLayerArtist):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         old_scatter = self.scatter
-        self.scatter = Lines(scales=self.scales, x=[0,1], y=[0,1], marker=None)
+        self.scatter = Lines(scales=self.scales, x=[0,1], y=[0,1], marker=None, colors=['#507FB6'])
         self.view.figure.marks = list(filter(lambda x: x is not old_scatter, self.view.figure.marks)) + [self.scatter]
-        self.scatter.colors = ['#507FB6']
         
 class SpectrumView(BqplotScatterView):
 
@@ -53,8 +59,8 @@ class SpectrumView(BqplotScatterView):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.resolution_x = 0
-        self.resolution_y = 0
+        self.figure_size_x = 0
+        self.figure_size_y = 230
         self.element = None
         
         self.user_line = Lines(
@@ -159,10 +165,12 @@ class SpectrumView(BqplotScatterView):
         
         self.add_event_callback(self._on_mouse_moved, events=['mousemove'])
         self.add_event_callback(self._on_click, events=['click'])
-        self.scale_y.observe(self._on_view_change, names=['min', 'max'])
+        self.scale_y.observe(self._update_locations, names=['min', 'max'])
 
-        add_callback(self.state, 'y_min', self._on_view_change)
-        add_callback(self.state, 'y_max', self._on_view_change)
+        add_callback(self.state, 'y_min', self._on_ymin_change, echo_old=True)
+        add_callback(self.state, 'y_max', self._on_ymax_change, echo_old=True)
+        add_callback(self.state, 'resolution_x', self._update_x_locations)
+        add_callback(self.state, 'resolution_y', self._update_y_locations)
         self.toolbar.observe(self._active_tool_change, names=['active_tool'])
 
     @staticmethod
@@ -170,18 +178,31 @@ class SpectrumView(BqplotScatterView):
         return f"{value:.0f} Å"
 
     def _x_background_coordinates(self, x):
-        return [x + 10 * self.resolution_x, x + 65 * self.resolution_x]
+        return [x + 10 * self.state.resolution_x, x + 65 * self.state.resolution_x]
 
     def _y_background_coordinates(self, y):
-        return [y - 10 * self.resolution_y, y - 10 * self.resolution_y]
+        return [y - 10 * self.state.resolution_y, y - 10 * self.state.resolution_y]
 
     def _active_tool_change(self, change):
         is_tool = change.new is not None
         line_visible = not is_tool or change.new.tool_id != 'hubble:wavezoom'
-        self.user_line.visible = line_visible
-        self.user_line_label.visible = line_visible
+        for mark in [self.user_line, self.user_line_label, self.label_background,
+                     self.previous_line, self.previous_line_label, self.previous_label_background]:
+            mark.visible = line_visible
 
-    def _on_view_change(self, event=None):
+    def _on_ymin_change(self, old, new):
+        if old is not None:
+            ymax = self.state.y_max
+            self.state.resolution_y *= (ymax - new + 20) / (ymax - old + 20)
+        self._update_y_locations()
+
+    def _on_ymax_change(self, old, new):
+        if old is not None:
+            ymin = self.state.y_min
+            self.state.resolution_y *= (new - ymin + 20) / (old - ymin + 20)
+        self._update_y_locations()
+
+    def _update_y_locations(self, resolution=None):
         scale = self.scales['y']
         ymin, ymax = scale.min, scale.max
         
@@ -193,16 +214,22 @@ class SpectrumView(BqplotScatterView):
         bottom_label_position = ymax * 0.91
         self.user_line.y = line_bounds
         self.previous_line.y = line_bounds
-        self.user_line_label.x = [self.user_line.x[0]]
         self.user_line_label.y = [self.user_line.y[1]]
-        self.label_background.x = self._x_background_coordinates(self.user_line_label.x[0])
         self.label_background.y = self._y_background_coordinates(self.user_line_label.y[0])
-        self.previous_line_label.x = [self.previous_line.x[0]]
         self.previous_line_label.y = [self.previous_line.y[1]]
-        self.previous_label_background.x = self._x_background_coordinates(self.previous_line_label.x[0])
         self.previous_label_background.y = self._y_background_coordinates(self.previous_line_label.y[0])
         self.element_tick.y = tick_bounds
         self.element_label.y = [bottom_label_position]
+
+    def _update_x_locations(self, resolution=None):
+        self.user_line_label.x = [self.user_line.x[0]]
+        self.label_background.x = self._x_background_coordinates(self.user_line_label.x[0])
+        self.previous_line_label.x = [self.previous_line.x[0]]
+        self.previous_label_background.x = self._x_background_coordinates(self.previous_line_label.x[0])
+
+    def _update_locations(self, event=None):
+        self._update_x_locations()
+        self._update_y_locations()
   
     def _on_mouse_moved(self, event):
 
@@ -214,8 +241,12 @@ class SpectrumView(BqplotScatterView):
         pixel_x = event['pixel']['x']
         y = event['domain']['y']
         pixel_y = event['pixel']['y']
-        self.resolution_x = (new_x - self.state.x_min) / pixel_x
-        self.resolution_y = (self.state.y_max - y) / (pixel_y - 10) # The y-axis has 10px "extra" on the top and bottom
+        self.state.resolution_x = (new_x - self.state.x_min) / pixel_x
+        if self.state.resolution_x != 0:
+            self.figure_size_x = (self.state.x_max - self.state.x_min) / self.state.resolution_x
+        self.state.resolution_y = (self.state.y_max - y) / (pixel_y - 10) # The y-axis has 10px "extra" on the top and bottom
+        if self.state.resolution_y != 0:
+            self.figure_size_y = (self.state.y_max - self.state.y_min) / self.state.resolution_y
         self.user_line_label.text = [self._label_text(new_x)]
         self.user_line.x = [new_x, new_x]
         self.user_line_label.x = [new_x, new_x]
@@ -231,6 +262,7 @@ class SpectrumView(BqplotScatterView):
         self.previous_label_background.y = self._y_background_coordinates(self.previous_line_label.y[0])
         self.previous_line.visible = True
         self.previous_line_label.visible = True
+        self.previous_label_background.visible = True
 
     def update(self, name, element, z, previous=None):
         self.spectrum_name = name
@@ -247,6 +279,7 @@ class SpectrumView(BqplotScatterView):
         has_previous = previous is not None
         self.previous_line.visible = has_previous
         self.previous_line_label.visible = has_previous
+        self.previous_label_background.visible = has_previous
         if has_previous:
             self.previous_line.x = [previous, previous]
             self.previous_line_label.x = [previous, previous]
@@ -255,7 +288,7 @@ class SpectrumView(BqplotScatterView):
         self.element_label.x = [self.shifted, self.shifted]
         self.element_label.text = [element]
         self.element_tick.x = [self.shifted, self.shifted]
-        self._on_view_change()
+        self._update_locations()
 
     def add_data(self, data):
         super().add_data(data)
@@ -285,6 +318,13 @@ class SpectrumView(BqplotScatterView):
             mode_cls = viewer_tool.members[tool_id]
             mode = mode_cls(self)
             self.toolbar.add_tool(mode)
+        
+        zoom_tool = self.toolbar.tools["hubble:wavezoom"]
+
+        zoom_tool.on_zoom = self.on_xzoom
+
+    def on_xzoom(self, old_state, new_state):
+        self.state.resolution_x *= (new_state.x_max - new_state.x_min) / (old_state.x_max - old_state.x_min)
 
     @property
     def line_visible(self):

--- a/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
+++ b/cosmicds/stories/hubbles_law/viewers/spectrum_view.py
@@ -39,7 +39,7 @@ class SpectrumViewLayerArtist(BqplotScatterLayerArtist):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         old_scatter = self.scatter
-        self.scatter = Lines(scales=self.scales, x=[0,1], y=[0,1], marker=None, colors=['#507FB6'])
+        self.scatter = Lines(scales=self.scales, x=[0,1], y=[0,1], marker=None, colors=['#507FB6'], stroke_width=1.8)
         self.view.figure.marks = list(filter(lambda x: x is not old_scatter, self.view.figure.marks)) + [self.scatter]
         
 class SpectrumView(BqplotScatterView):
@@ -105,7 +105,7 @@ class SpectrumView(BqplotScatterView):
                 'x': self.scales['x'],
                 'y': self.scales['y'],
             },
-            colors=['gray'],
+            colors=['#a7a5a5'],
             visible=False
         )
 
@@ -119,7 +119,7 @@ class SpectrumView(BqplotScatterView):
                 'x': self.scales['x'],
                 'y': self.scales['y'],
             },
-            colors=['#4c4a4a'],
+            colors=['#747272'],
             visible=False
         )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ include_package_data = True
 install_requires = 
   numpy <= 1.22
   glue-core
-  glue-jupyter
+  glue-jupyter >= 0.12
   pywwt @ git+https://github.com/Carifio24/pywwt@prekdr
   pyqt5
   PyQtWebEngine


### PR DESCRIPTION
This PR makes some additional visual updates to the spectrum viewer, which are outlined below. Suggestions on tweaks to these updates are welcome.

* The previous line label now has a white background as well
* The opacity for both label backgrounds has been set to 0.7, so that the data can be somewhat seen behind the background
* The positions of element labels have been adjusted so that the two labels don't overlap when the rest wavelength tool is active

I've also pinned `glue-jupyter >= 0.12` in `setup.cfg`. There was a bug in older versions of glupyter where all event callbacks were fired on every event, regardless of which events they were assigned to. I fixed this bug, and it will make things easier if we know we don't have to account for it. (This is relevant for some of the items in this PR, which rely on bqplot events to update their placement).