### PR TITLE
Update tickmarks based on viewer/application state

### DIFF
--- a/cosmicds/components/viewer_layout/viewer_layout.py
+++ b/cosmicds/components/viewer_layout/viewer_layout.py
@@ -1,6 +1,6 @@
 from ipyvuetify import VuetifyTemplate
 from ipywidgets import widget_serialization
-from traitlets import Bool, Dict, Instance, Unicode
+from traitlets import Bool, Dict, Instance, List, Unicode
 from ipywidgets import DOMWidget
 
 from ...utils import load_template
@@ -14,12 +14,14 @@ class ViewerLayout(VuetifyTemplate):
     css_style = Dict().tag(sync=True)
     show_toolbar = Bool(True).tag(sync=True)
     title = Unicode().tag(sync=True)
+    classes = List().tag(sync=True)
 
-    def __init__(self, viewer, style=None, *args, **kwargs):
+    def __init__(self, viewer, classes=None, style=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.viewer = viewer
         self.title = viewer.LABEL
+        self.classes = classes or []
         self.show_toolbar = kwargs.get("show_toolbar", True)
         self.controls = dict(
             toolbar_selection_tools=viewer.toolbar_selection_tools,

--- a/cosmicds/components/viewer_layout/viewer_layout.vue
+++ b/cosmicds/components/viewer_layout/viewer_layout.vue
@@ -1,6 +1,7 @@
 <template>
   <v-card
     flat
+    :class="classes"
   >
     <v-toolbar
       color="primary"

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -106,7 +106,7 @@ class Stage(TemplateMixin):
         if viewer_label is not None:
             viewer.LABEL = viewer_label
         current_viewers = {k: v for k, v in self.viewers.items()}
-        viewer_layout = layout(viewer)
+        viewer_layout = layout(viewer, classes=[label])
         viewer_layout.show_toolbar = show_toolbar
         current_viewers.update({label: viewer_layout})
         self.viewers = current_viewers

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -212,3 +212,12 @@ class Stage(TemplateMixin):
 
     def vue_set_step_complete(self, value):
         self.story_state.step_complete = value
+
+    def vue_set_viewer_nticks(self, args):
+        viewer = self.get_viewer(args["viewer"])
+        nticks = args["nticks"]
+        axis = args["axis"]
+        if axis == "x":
+            viewer.update_nxticks(nticks)
+        elif axis == "y":
+            viewer.update_nyticks(nticks)

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -218,6 +218,6 @@ class Stage(TemplateMixin):
         nticks = args["nticks"]
         axis = args["axis"]
         if axis == "x":
-            viewer.update_nxticks(nticks)
+            viewer.state.nxticks = nticks
         elif axis == "y":
-            viewer.update_nyticks(nticks)
+            viewer.state.nyticks = nticks

--- a/cosmicds/viewers/cds_viewers.py
+++ b/cosmicds/viewers/cds_viewers.py
@@ -140,12 +140,6 @@ def cds_viewer(viewer_class, name, viewer_tools=[], label=None, state_cls=None):
                 return False
             return super().add_subset(subset)
 
-        def _on_xaxis_change(self, change):
-            self.state.update_xticks(**{ change["name"] : change["new"] })
-
-        def _on_yaxis_change(self, change):
-            self.state.update_yticks(**{ change["name"] : change["new"] })
-
         def _update_xtick_values(self, values):
             self.axis_x.tick_values = values
         

--- a/cosmicds/viewers/cds_viewers.py
+++ b/cosmicds/viewers/cds_viewers.py
@@ -3,6 +3,7 @@
 
 from math import ceil, floor
 
+from echo import add_callback, callback_property, CallbackProperty
 from glue.config import viewer_tool
 from glue_jupyter.bqplot.scatter import BqplotScatterView
 from glue_jupyter.bqplot.histogram import BqplotHistogramView
@@ -10,31 +11,118 @@ from numpy import linspace
 
 from cosmicds.components.toolbar import Toolbar
 
+def cds_viewer_state(state_class):
 
-def cds_viewer(viewer_class, name=None, viewer_tools=None, label=None, state_cls=None):
+    class CDSViewerState(state_class):
+
+        TICK_SPACINGS = tick_spacings = [2000, 1500, 1000, 500, 250, 200, 100, 75, 50, 25, 10, 5, 2, 1, 0.75, 0.5, 0.2, 0.1]
+
+        xtick_values = CallbackProperty([])
+        ytick_values = CallbackProperty([])
+
+        @callback_property
+        def nxticks(self):
+            return self._nxticks
+
+        @nxticks.setter
+        def nxticks(self, nticks):
+            if nticks == self._nxticks:
+                return
+            self._nxticks = max(nticks, 1)
+            self.update_xticks()
+
+        @callback_property
+        def nyticks(self):
+            return self._nyticks
+
+        @nyticks.setter
+        def nyticks(self, nticks):
+            if nticks == self._nyticks:
+                return
+            self._nyticks = max(nticks, 1)
+            self.update_yticks()
+
+        
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._nxticks = 7
+            self._nyticks = 7
+            add_callback(self, "x_min", self._update_xmin)
+            add_callback(self, "x_max", self._update_xmax)
+            add_callback(self, "y_min", self._update_ymin)
+            add_callback(self, "y_max", self._update_ymax)
+
+        def _update_xmin(self, value):
+            self.update_xticks(min=value)
+
+        def _update_xmax(self, value):
+            self.update_xticks(max=value)
+
+        def _update_ymin(self, value):
+            self.update_yticks(min=value)
+
+        def _update_ymax(self, value):
+            self.update_yticks(max=value)
+
+        def update_xticks(self, min=None, max=None):
+            min = min or self.x_min
+            max = max or self.x_max
+            if min is None or max is None:
+                return
+            x_range = max - min
+            frac = int(x_range / self.nxticks)
+            spacing = next((t for t in self.TICK_SPACINGS if frac > t), self.TICK_SPACINGS[-1])
+            self.set_xtick_spacing(spacing)
+
+        def update_yticks(self, min=None, max=None):
+            min = min or self.y_min
+            max = max or self.y_max
+            if min is None or max is None:
+                return
+            y_range = max - min
+            frac = int(y_range / self.nyticks)
+            spacing = next((t for t in self.TICK_SPACINGS if frac > t), self.TICK_SPACINGS[-1])
+            self.set_ytick_spacing(spacing)
+
+        def set_xtick_spacing(self, spacing):
+            tmin = ceil(self.x_min / spacing) * spacing
+            tmax = floor(self.x_max / spacing) * spacing
+            n = int((tmax - tmin) / spacing) + 1
+            self.xtick_values = list(linspace(tmin, tmax, n))
+
+        def set_ytick_spacing(self, spacing):
+            tmin = ceil(self.y_min / spacing) * spacing
+            tmax = floor(self.y_max / spacing) * spacing
+            n = int((tmax - tmin) / spacing) + 1
+            self.ytick_values = list(linspace(tmin, tmax, n))
+
+    return CDSViewerState
+
+
+def cds_viewer(viewer_class, name, viewer_tools=[], label=None, state_cls=None):
+
+    state_class = state_cls or viewer_class._state_cls
+    cds_state_class = cds_viewer_state(state_class)
+
     class CDSViewer(viewer_class):
 
         __name__ = name
         __qualname__ = name
-        _state_cls = state_cls or viewer_class._state_cls
+        _state_cls = cds_state_class
         inherit_tools = viewer_tools is None
         tools = viewer_tools or viewer_class.tools
         LABEL = label or viewer_class.LABEL
 
-        TICK_SPACINGS = tick_spacings = [2000, 1500, 1000, 500, 250, 200, 100, 75, 50, 25, 10, 5, 2, 1, 0.75, 0.5, 0.2, 0.1]
-
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.ignore_conditions = []
-            self.nxticks = 7
-            self.nyticks = 7
-            self.scale_x.observe(self._on_xaxis_change, names=['min', 'max'])
-            self.scale_y.observe(self._on_yaxis_change, names=['min', 'max'])
+            add_callback(self.state, "xtick_values", self._update_xtick_values)
+            add_callback(self.state, "ytick_values", self._update_ytick_values)
 
         def initialize_toolbar(self):
             self.toolbar = Toolbar(self)
 
-            for tool_id in viewer_tools:
+            for tool_id in self.tools:
                 mode_cls = viewer_tool.members[tool_id]
                 mode = mode_cls(self)
                 self.toolbar.add_tool(mode)
@@ -53,56 +141,17 @@ def cds_viewer(viewer_class, name=None, viewer_tools=None, label=None, state_cls
             return super().add_subset(subset)
 
         def _on_xaxis_change(self, change):
-            self.update_xticks(**{ change["name"] : change["new"] })
+            self.state.update_xticks(**{ change["name"] : change["new"] })
 
         def _on_yaxis_change(self, change):
-            self.update_yticks(**{ change["name"] : change["new"] })
+            self.state.update_yticks(**{ change["name"] : change["new"] })
 
-        def update_nxticks(self, nticks):
-            if nticks == self.nxticks:
-                return
-            self.nxticks = max(nticks, 1)
-            self.update_xticks()
+        def _update_xtick_values(self, values):
+            self.axis_x.tick_values = values
+        
+        def _update_ytick_values(self, values):
+            self.axis_y.tick_values = values
 
-        def update_nyticks(self, nticks):
-            if nticks == self.nyticks:
-                return
-            self.nyticks = max(nticks, 1)
-            self.update_yticks()
-
-        def update_xticks(self, min=None, max=None):
-            min = min or self.state.x_min
-            max = max or self.state.x_max
-            if min is None or max is None:
-                return
-            x_range = max - min
-            frac = int(x_range / self.nxticks)
-            spacing = next((t for t in self.TICK_SPACINGS if frac > t), self.TICK_SPACINGS[-1])
-            self.set_xtick_spacing(spacing)
-
-        def update_yticks(self, min=None, max=None):
-            min = min or self.state.y_min
-            max = max or self.state.y_max
-            if min is None or max is None:
-                return
-            y_range = max - min
-            frac = int(y_range / self.nyticks)
-            spacing = next((t for t in self.TICK_SPACINGS if frac > t), self.TICK_SPACINGS[-1])
-            self.set_ytick_spacing(spacing)
-
-        def set_xtick_spacing(self, spacing):
-            xmin, xmax = self.state.x_min, self.state.x_max
-            tmin = ceil(xmin / spacing) * spacing
-            tmax = floor(xmax / spacing) * spacing
-            n = int((tmax - tmin) / spacing) + 1
-            self.axis_x.tick_values = list(linspace(tmin, tmax, n))
-
-        def set_ytick_spacing(self, spacing):
-            ymin, ymax = self.state.y_min, self.state.y_max
-            tmin = ceil(ymin / spacing) * spacing
-            tmax = floor(ymax / spacing) * spacing
-            n = int((tmax - tmin) / spacing) + 1
-            self.axis_y.tick_values = list(linspace(tmin, tmax, n))
         
     return CDSViewer
 

--- a/cosmicds/viewers/cds_viewers.py
+++ b/cosmicds/viewers/cds_viewers.py
@@ -21,12 +21,13 @@ def cds_viewer(viewer_class, name=None, viewer_tools=None, label=None, state_cls
         tools = viewer_tools or viewer_class.tools
         LABEL = label or viewer_class.LABEL
 
-        TICK_SPACINGS = tick_spacings = [2000, 1500, 1000, 500, 250, 100, 50, 25, 10, 5]
+        TICK_SPACINGS = tick_spacings = [2000, 1500, 1000, 500, 250, 200, 100, 75, 50, 25, 10, 5, 2, 1, 0.75, 0.5, 0.2, 0.1]
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.ignore_conditions = []
             self.nxticks = 7
+            self.nyticks = 7
             self.scale_x.observe(self._on_xaxis_change, names=['min', 'max'])
             self.scale_y.observe(self._on_yaxis_change, names=['min', 'max'])
 
@@ -60,18 +61,20 @@ def cds_viewer(viewer_class, name=None, viewer_tools=None, label=None, state_cls
         def update_nxticks(self, nticks):
             if nticks == self.nxticks:
                 return
-            self.nxticks = nticks
+            self.nxticks = max(nticks, 1)
             self.update_xticks()
 
         def update_nyticks(self, nticks):
             if nticks == self.nyticks:
                 return
-            self.nyticks = nticks
+            self.nyticks = max(nticks, 1)
             self.update_yticks()
 
         def update_xticks(self, min=None, max=None):
             min = min or self.state.x_min
             max = max or self.state.x_max
+            if min is None or max is None:
+                return
             x_range = max - min
             frac = int(x_range / self.nxticks)
             spacing = next((t for t in self.TICK_SPACINGS if frac > t), self.TICK_SPACINGS[-1])
@@ -80,6 +83,8 @@ def cds_viewer(viewer_class, name=None, viewer_tools=None, label=None, state_cls
         def update_yticks(self, min=None, max=None):
             min = min or self.state.y_min
             max = max or self.state.y_max
+            if min is None or max is None:
+                return
             y_range = max - min
             frac = int(y_range / self.nyticks)
             spacing = next((t for t in self.TICK_SPACINGS if frac > t), self.TICK_SPACINGS[-1])


### PR DESCRIPTION
This PR adds functionality for updating the tick mark settings of a viewer automatically during runtime. All of the changes described here are added to our `cds_viewer` class factory so that all our viewers will benefit.

The basic idea is that we add `nxticks` and `nyticks` properties to the viewer state. These values serve as recommendations for how many ticks we want to display on each axis. Whenever the axis bounds are changed, a new tick spacing is chosen from a set of "nice" values (see [here](https://github.com/Carifio24/cosmicds/blob/update-ticks/cosmicds/viewers/cds_viewers.py#L18)) based on the axis range and appropriate tick number recommendation.

This PR also adds the (Vue-exposed) method `vue_set_viewer_nticks` method to the `Stage` class to allow stages to set the tick numbers from JavaScript as they see fit. Additionally, when a viewer is added to a stage via `add_viewer`, whatever name is used for the viewer will be added as a class to the root element of the `ViewerLayout` template, so that stages can find these viewers in the DOM more easily. The PR https://github.com/cosmicds/cosmicds-hubble/pull/3 does this tick number updating for the Hubble data story.