### PR TITLE
Use story-defined titles

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -20,7 +20,7 @@
       <v-app-bar-nav-icon @click="drawer = !drawer"></v-app-bar-nav-icon>
 
       <v-toolbar-title class="mr-5">
-        <h2>Hubble's Law</h2>
+        <h2>{{ story_state.title }}</h2>
       </v-toolbar-title>
 
       <v-toolbar-title>Cosmic Data Stories</v-toolbar-title>


### PR DESCRIPTION
This PR removes the hard coded story title in the main application and instead references the `title` attribute of a story's state.