### PR TITLE
Hide bqplot legend "checkmark" symbols

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -575,4 +575,7 @@ input {
   z-index: 40;
 }
 
+.g_legend .line {
+  display: none;
+}
 </style>

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -575,7 +575,8 @@ input {
   z-index: 40;
 }
 
-.g_legend .line {
+/** Hide bqplot legend 'checkmark' symbols */
+.g_legend path.line {
   display: none;
 }
 </style>


### PR DESCRIPTION
This PR hides the "checkmark" symbols that appear in the bqplot legends. I couldn't find a way to do this in bqplot itself, so this is accomplished using some CSS. Currently this is done at the top level of the app, and so these symbols will be hidden by default. In the unlikely event that we do want these a story at some point, the stages there can override this CSS.