### PR TITLE
Set visual properties of subset groups on creation

### DIFF
--- a/cosmicds/components/table/table.py
+++ b/cosmicds/components/table/table.py
@@ -171,8 +171,7 @@ class Table(VuetifyTemplate, HubListener):
     def _new_subset(self):
         state = self.subset_state_from_selected(self.selected)
         if self.use_subset_group:
-            subset = self.data_collection.new_subset_group(label=self._subset_label, subset_state=state)
-            subset.style.color = self.subset_color
+            subset = self.data_collection.new_subset_group(label=self._subset_label, subset_state=state, color=self.subset_color)
         else:
             subset = self._glue_data.new_subset(label=self._subset_label, subset=state, color=self.subset_color)
         if self._on_create_subset is not None:

--- a/cosmicds/message.py
+++ b/cosmicds/message.py
@@ -1,0 +1,7 @@
+from glue.core.message import Message
+
+__all__ = ["CDSLayersUpdatedMessage"]
+
+class CDSLayersUpdatedMessage(Message):
+    def __init__(self, sender, tag=None):
+        super().__init__(sender, tag=tag)

--- a/cosmicds/viewers/cds_viewers.py
+++ b/cosmicds/viewers/cds_viewers.py
@@ -10,6 +10,7 @@ from glue_jupyter.bqplot.histogram import BqplotHistogramView
 from numpy import linspace
 
 from cosmicds.components.toolbar import Toolbar
+from cosmicds.message import CDSLayersUpdatedMessage
 
 def cds_viewer_state(state_class):
 
@@ -118,6 +119,12 @@ def cds_viewer(viewer_class, name, viewer_tools=[], label=None, state_cls=None):
             self.ignore_conditions = []
             add_callback(self.state, "xtick_values", self._update_xtick_values)
             add_callback(self.state, "ytick_values", self._update_ytick_values)
+
+            self._layer_artist_container.on_changed(self._send_layers_updated_message)
+
+        def _send_layers_updated_message(self, *args):
+            message = CDSLayersUpdatedMessage(self)
+            self._hub.broadcast(message)
 
         def initialize_toolbar(self):
             self.toolbar = Toolbar(self)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ setup_requires = setuptools_scm
 include_package_data = True
 install_requires = 
   numpy
-  glue-core
+  glue-core >= 1.4
   glue-jupyter >= 0.12
   pywwt @ git+https://github.com/Carifio24/pywwt@prekdr
   astropy


### PR DESCRIPTION
Checking in from abroad with a quick update. This PR modifies the places where our code creates subset groups to use the functionality that I added (with this project in mind) in https://github.com/glue-viz/glue/pull/2297. This lets us specify the visual attributes of the subset group when it's created, rather than waiting until the subset group is created and then updating it. In order to use this, we need to pin to `glue >= 1.4`, so this PR does that. This should prevent any quick flashes of color-changing when the subset group is first created.

If someone's looking to test this out, the table <--> scatter plot interaction near the beginning of stage 3 is one area where we create a subset group (which component creates the group depends on which one the student uses first).