### PR TITLE
Pin ipywidgets < 8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ setup_requires = setuptools_scm
 include_package_data = True
 install_requires = 
   numpy
+  ipywidgets < 8
   glue-core >= 1.4
   glue-jupyter >= 0.12
   pywwt @ git+https://github.com/Carifio24/pywwt@prekdr


### PR DESCRIPTION
As @patudom, @LilyN11, and I saw yesterday, using ipywidgets 8.x can cause some issues - in particular, the WWT viewer wouldn't display (though the error messages make me think that the real problem relates to one of the other extensions). Until we have a chance to figure that out, this PR pins `ipywidgets < 8`. I put the pin here (rather than in hubbleds) since this is where the pywwt dependency lives.