### PR TITLE
Allow Stage instances to know their story index

### DIFF
--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -107,6 +107,8 @@ class Stage(TemplateMixin):
         self.story_state = story_state
         self.app_state = app_state
 
+        self.index = 0
+
     def add_viewer(self, cls, label, viewer_label=None, data=None, layout=ViewerLayout, show_toolbar=True):
         viewer = self.app.new_data_viewer(cls, data=data, show=False)
         if viewer_label is not None:

--- a/cosmicds/registries.py
+++ b/cosmicds/registries.py
@@ -74,6 +74,7 @@ class StoryRegistry(UniqueDictRegistry):
 
         for k, v in story_entry['stages'].items():
             stage = v['cls'](session, story_state, app_state)
+            stage.index = k
             if state is not None and "state" in state["stages"][k]:
                 stage.stage_state.update_from_dict(state["stages"][k]["state"])
             


### PR DESCRIPTION
This PR adds an `index` property to each stage instance that lets it know at what index it's located in its particular story. This property gets assigned by the story during `setup_story`. I made this an instance-level property rather than a class-level one to minimize the coupling between story and stage classes (though I can't imagine a stage would ever belong to more than one story).