### PR TITLE
Keep MathJax equations from moving when focused

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -571,6 +571,10 @@ input {
   height: fit-content;
 }
 
+mjx-container[jax="CHTML"][display="true"] {
+  display: block !important;
+}
+
 /* issues with empty headers pushing WWT widget south, anyone else having this problem? -HOH */
 .wwt_column {
   overflow-y: hidden;


### PR DESCRIPTION
This is a small PR to fix a small, but very visible, issue. Currently, MathJax equations will change from `display: block` to `display: inline-table` when focused. This can cause equations to move from being centered to left-aligned (see the video below), or cause two equations to collapse into the same line.

https://user-images.githubusercontent.com/14281631/195954389-dbe3e995-d113-4e67-8e80-b2b6edcbdc4e.mp4

This PR adds some CSS that, at least in my browser, fixes the issue. I was surprised that I couldn't just use `.MathJax:focus` as the selector, but the HTML generated from MathJax can be complicated, and I don't think it's worth spending much time exploring its intricacies since what I've got here seems to get the job done.