### PR TITLE
Updates from state testing, part 1

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -58,11 +58,6 @@ class Application(VuetifyTemplate, HubListener):
         self.story_state = story_registry.setup_story(story, self.session,
                                                       self.app_state)
 
-        # Initialize from database
-        if self.app_state.update_db:
-            # self._initialize_from_database()
-            pass
-
         # Subscribe to events
         self.hub.subscribe(self, WriteToDatabaseMessage,
                            handler=self._on_write_to_database)

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -5,6 +5,7 @@ from cosmicds.components.viewer_layout import ViewerLayout
 from cosmicds.events import WriteToDatabaseMessage
 
 from cosmicds.mixins import TemplateMixin, HubMixin
+from cosmicds.utils import debounce
 from glue.core import Data
 from glue.core.state_objects import State
 from echo import DictCallbackProperty, CallbackProperty, add_callback
@@ -58,7 +59,8 @@ class Story(CDSState, HubMixin):
         add_callback(self, 'stage_index', self._on_stage_index_changed)
         add_callback(self, 'mc_scoring', self._update_total_score)
 
-    def _write_to_db(self, *args, **kwargs):
+    @debounce(wait=2)
+    def write_to_db(self, *args, **kwargs):
         self.hub.broadcast(WriteToDatabaseMessage(self))
 
     def _modified_import_dict(self, state_dict):
@@ -74,26 +76,26 @@ class Story(CDSState, HubMixin):
         return d
 
     def _on_stage_index_changed(self, value):
-        self._write_to_db()
+        self.write_to_db()
 
     def _on_step_index_changed(self, value):
         self.stages[self.stage_index]['step_index'] = value
         self.step_index = min(value, len(self.stages[self.stage_index]['steps'])-1)
         self.step_complete = self.stages[self.stage_index]['steps'][
             self.step_index]['completed']
-        self._write_to_db()
+        self.write_to_db()
 
     def _on_step_complete_changed(self, value):
         self.stages[self.stage_index]['steps'][self.step_index][
             'completed'] = value
-        self._write_to_db()
+        self.write_to_db()
 
     def viewers(self):
         return self.app.viewers
 
     def _update_total_score(self, mc_scoring):
         self.total_score = sum(mc["score"] for stage in mc_scoring.values() for mc in stage.values())
-        self._write_to_db()
+        self.write_to_db()
 
     # Data can be data, a subset, or a subset group
     def set_layer_visible(self, data, viewers):

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -14,13 +14,22 @@ from numpy import delete
 class CDSState(State):
     _NONSERIALIZED_PROPERTIES = []
 
+    def _modified_dict(self, state_dict):
+        return { k : v for k, v in state_dict.items() if k not in self._NONSERIALIZED_PROPERTIES }
+
+    def _modified_output_dict(self, state_dict):
+        return self._modified_dict(state_dict)
+
+    def _modified_import_dict(self, state_dict):
+        return self._modified_dict(state_dict)
+
     def update_from_dict(self, state_dict):
-        state_dict = { k : v for k, v in state_dict.items() if k not in self._NONSERIALIZED_PROPERTIES }
+        state_dict = self._modified_import_dict(state_dict)
         super().update_from_dict(state_dict)
 
     def as_dict(self):
         state_dict = super().as_dict()
-        return { k : v for k, v in state_dict.items() if k not in self._NONSERIALIZED_PROPERTIES }
+        return self._modified_output_dict(state_dict)
 
 
 class Story(CDSState, HubMixin):
@@ -48,6 +57,18 @@ class Story(CDSState, HubMixin):
         add_callback(self, 'step_complete', self._on_step_complete_changed)
         add_callback(self, 'stage_index', self._on_stage_index_changed)
         add_callback(self, 'mc_scoring', self._update_total_score)
+
+    def _modified_import_dict(self, state_dict):
+        d = super()._modified_dict(state_dict)
+
+        # We want to make sure that we don't set the model_id ourselves
+        # since this will completely break the frontend's ability to
+        # find our widgets
+        if "stages" in d:
+            for v in d["stages"].values():
+                if "model_id" in v:
+                    del v["model_id"]
+        return d
 
     def _on_stage_index_changed(self, value):
         self.hub.broadcast(WriteToDatabaseMessage(self))

--- a/cosmicds/registries.py
+++ b/cosmicds/registries.py
@@ -1,8 +1,6 @@
 from glue.config import DictRegistry
 from ipyvuetify import VuetifyTemplate
-from ipywidgets import Widget
 from glue.core.state_objects import State
-import warnings
 import requests
 
 from cosmicds.utils import API_URL
@@ -76,6 +74,8 @@ class StoryRegistry(UniqueDictRegistry):
             stage = v['cls'](session, story_state, app_state)
             if state is not None and "state" in state["stages"][k]:
                 stage.stage_state.update_from_dict(state["stages"][k]["state"])
+
+            stage.stage_state.add_global_callback(story_state.write_to_db)
             
             story_state.stages[k] = {"title": stage.title,
                                      "subtitle": stage.subtitle,

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -15,7 +15,8 @@ __all__ = [
     'load_template', 'update_figure_css', 'extend_tool',
     'convert_material_color', 'fit_line', 
     'line_mark', 'vertical_line_mark',
-    'API_URL', 'CDSJSONEncoder', 'RepeatedTimer'
+    'API_URL', 'CDSJSONEncoder', 'RepeatedTimer',
+    'debounce'
 ]
 
 # The URL for the CosmicDS API
@@ -252,3 +253,28 @@ def vertical_line_mark(layer, x, color, label=None):
     """
     viewer_state = layer.state.viewer_state
     return line_mark(layer, x, viewer_state.y_min, x, viewer_state.y_max, color, label)
+
+# Taken from https://jonlabelle.com/snippets/view/python/python-debounce-decorator-function
+def debounce(wait):
+    """Postpone a functions execution until after some time has elapsed
+ 
+    :type wait: int
+    :param wait: The amount of Seconds to wait before the next call can execute.
+    """
+
+    def decorator(fun):
+        def debounced(*args, **kwargs):
+            def call_it():
+                fun(*args, **kwargs)
+
+            try:
+                debounced.t.cancel()
+            except AttributeError:
+                pass
+
+            debounced.t = Timer(wait, call_it)
+            debounced.t.start()
+
+        return debounced
+
+    return decorator


### PR DESCRIPTION
This PR, together with a companion one on the hubbleds repository, contains the first of what I expect will be a few batches of updates resulting from the state testing branch.

This PR contains the following changes
* We add a global callback to each stage state that triggers a database write each time one of its properties changes. This is a pretty straightforward way to make sure that the state in the database is always up to date with what the student has done. This update is debounced with a wait time of 2 seconds to avoid an excessive number of database updates.
* For technical reasons, we explicitly make sure NOT to use any model IDs that get serialized to the database

Possible concern: I'm curious how this behaves on everyone's machine. Even debounced, do the additional database writes affect performance? If it's a problem, there are definitely other ways we can consider to try to keep the stored state as fresh as possible (e.g. auto-save every minute).