### PR TITLE
Allow state testing on main branch

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -46,21 +46,26 @@ class Application(VuetifyTemplate, HubListener):
         self.app_state.show_team_interface = kwargs.get("show_team_interface",
                                                         True)
 
-        # # For testing purposes, we create a new dummy student on each startup
-        # if self.app_state.update_db:
-        #     response = requests.get(f"{API_URL}/new-dummy-student").json()
-        #     self.app_state.student = response["student"]
-
-        self.app_state.classroom["id"] = kwargs.get("class_id", 0)
-        self.app_state.student["id"] = kwargs.get("student_id", 0)
+        db_init = False
+        create_new = kwargs.get("create_new_student", False)
+        if create_new:
+            response = requests.get(f"{API_URL}/new-dummy-student").json()
+            self.app_state.student = response["student"]
+            self.app_state.classroom["id"] = 0
+            db_init = True
+            print(f"Student ID: {self.student_id}")
+        else:
+            self.app_state.classroom["id"] = kwargs.get("class_id", 0)
+            self.app_state.student["id"] = kwargs.get("student_id", 0)
+        self.student_id = self.app_state.student["id"]
 
         self._application_handler = JupyterApplication()
         self.story_state = story_registry.setup_story(story, self.session,
                                                       self.app_state)
 
         # Initialize from database
-        if self.app_state.update_db:
-            # self._initialize_from_database()
+        if db_init:
+            self._initialize_from_database()
             pass
 
         # Subscribe to events


### PR DESCRIPTION
This PR adds the keyword options used in the state testing branch, so that we can use the main branch for testing state reloading issues. This will depend on the changes in #158  which is why I've marked it as a draft.