### PR TITLE
Allow allowing/restricting advancing in the story via a keyword argument

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -26,6 +26,7 @@ class ApplicationState(State):
     classroom = CallbackProperty({})
     update_db = CallbackProperty(False)
     show_team_interface = CallbackProperty(True)
+    allow_advancing = CallbackProperty(True)
 
 
 class Application(VuetifyTemplate, HubListener):
@@ -45,6 +46,7 @@ class Application(VuetifyTemplate, HubListener):
         self.app_state.update_db = kwargs.get("update_db", True)
         self.app_state.show_team_interface = kwargs.get("show_team_interface",
                                                         True)
+        self.app_state.allow_advancing = kwargs.get("allow_advancing", False)
 
         # # For testing purposes, we create a new dummy student on each startup
         # if self.app_state.update_db:

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -115,9 +115,10 @@
         <template v-for="(stage, key, index) in story_state.stages">
           <v-stepper-step
             :key="index"
-            :complete="story_state.stage_index > index"
+            :editable="app_state.allow_advancing || index == 0 || story_state.max_stage_index >= index"
+            :complete="story_state.max_stage_index > index"
             :step="index"
-            editable
+            :edit-icon="'$complete'"
           >
             {{ stage.title }}
           </v-stepper-step>

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -29,6 +29,7 @@ class Story(CDSState, HubMixin):
     stage_index = CallbackProperty(0)
     step_index = CallbackProperty(0)
     step_complete = CallbackProperty(False)
+    max_stage_index = CallbackProperty(0)
     stages = DictCallbackProperty()
     teacher_user = CallbackProperty()
     student_user = CallbackProperty()
@@ -50,6 +51,7 @@ class Story(CDSState, HubMixin):
         add_callback(self, 'mc_scoring', self._update_total_score)
 
     def _on_stage_index_changed(self, value):
+        self.max_stage_index = max(self.max_stage_index, value)
         self.hub.broadcast(WriteToDatabaseMessage(self))
 
     def _on_step_index_changed(self, value):


### PR DESCRIPTION
This PR adds the `allow_advancing` keyword argument, which will determine whether or not a user can freely advance through the story (that is, access a stage before completing the preceding ones). The default value is set as `False`, so you'll need to set it to `True` to have free rein to traverse the story.

In order to allow students to travel backwards, I've added a `max_stage_index` property to the story state that keeps track of the furthest stage that a student has reached, which is then used in the activation logic for the v-stepper steps.