### PR TITLE
Get student and class from JupyterHub username

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -61,7 +61,7 @@ class Application(VuetifyTemplate, HubListener):
         else:
             username = getenv("JUPYTERHUB_USER")
             if username is not None:
-                r = requests.get(f"{API_URL}/student/")
+                r = requests.get(f"{API_URL}/student/{username}")
                 student = r.json()["student"]
                 if student is not None:
                     self.app_state.student = student
@@ -76,8 +76,8 @@ class Application(VuetifyTemplate, HubListener):
         cls = r.json()["class"]
         self.app_state.classroom = cls or { "id": 0 }
 
-        print(self.student_id)
-        print(self.app_state.classroom["id"])
+        print(f"Student ID: {self.student_id}")
+        print(f"Class ID: {self.app_state.classroom['id']}")
 
         self._application_handler = JupyterApplication()
         self.story_state = story_registry.setup_story(story, self.session,

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -1,4 +1,5 @@
 import json
+from os import getenv
 
 import ipyvuetify as v
 import requests
@@ -46,6 +47,7 @@ class Application(VuetifyTemplate, HubListener):
         self.app_state.update_db = kwargs.get("update_db", True)
         self.app_state.show_team_interface = kwargs.get("show_team_interface",
                                                         True)
+
         self.app_state.allow_advancing = kwargs.get("allow_advancing", False)
 
         db_init = False
@@ -54,12 +56,28 @@ class Application(VuetifyTemplate, HubListener):
             response = requests.get(f"{API_URL}/new-dummy-student").json()
             self.app_state.student = response["student"]
             self.app_state.classroom["id"] = 0
+            self.student_id = self.app_state.student["id"]
             db_init = True
         else:
-            self.app_state.classroom["id"] = kwargs.get("class_id", 0)
-            self.app_state.student["id"] = kwargs.get("student_id", 0)
-        self.student_id = self.app_state.student["id"]
-        print(f"Student ID: {self.student_id}")
+            username = getenv("JUPYTERHUB_USER")
+            if username is not None:
+                r = requests.get(f"{API_URL}/student/")
+                student = r.json()["student"]
+                if student is not None:
+                    self.app_state.student = student
+                    self.student_id = student["id"]
+
+            if not self.app_state.student:
+                sid = kwargs.get("student_id", 0)
+                self.app_state.student["id"] = sid
+                self.student_id = sid
+            
+        r = requests.get(f"{API_URL}/class-for-student-story/{self.student_id}/{story}")
+        cls = r.json()["class"]
+        self.app_state.classroom = cls or { "id": 0 }
+
+        print(self.student_id)
+        print(self.app_state.classroom["id"])
 
         self._application_handler = JupyterApplication()
         self.story_state = story_registry.setup_story(story, self.session,

--- a/cosmicds/registries.py
+++ b/cosmicds/registries.py
@@ -73,7 +73,7 @@ class StoryRegistry(UniqueDictRegistry):
         for k, v in story_entry['stages'].items():
             stage = v['cls'](session, story_state, app_state)
             stage.index = k
-            if state is not None and "state" in state["stages"][k]:
+            if state is not None and k in state["stages"] and "state" in state["stages"][k]:
                 stage.stage_state.update_from_dict(state["stages"][k]["state"])
 
             stage.stage_state.add_global_callback(story_state.write_to_db)


### PR DESCRIPTION
This PR allows the app to obtain the student and relevant class information from the JupyterHub environment, where the username is exposed via the `JUPYTERHUB_USER` environment variable. For now we assume that each student will only be in one class that's doing a given story, but we should revisit this logic in the future. If the student isn't marked as being in a class that's doing the given story, a class ID of 0 is used.

Note that if you set `create_new_student=True`, that behavior will override looking at the JH environment variable. As long as the environment variable isn't set, you can still pass in `student_id` as a keyword argument to get a student that way.

To test this out, this environment variable can be explicitly set, e.g.:
```
import os
os.environ["JUPYTERHUB_USER"] = "dummy_student_2226"
```

Currently only the data generation students are assigned to a class. Most of these students will be started at the phase two intro if you load them up (since the number of states has changed since the data generation branch was created), but their UI state information doesn't really matter anyways.