### PR TITLE
Add method for grabbing layer artist instance

### DIFF
--- a/cosmicds/tools/line_fit_tool.py
+++ b/cosmicds/tools/line_fit_tool.py
@@ -263,8 +263,8 @@ class LineFitTool(Tool, HubListener, HasTraits):
     def _remove_line(self, layer):
         data = layer.state.layer
         line = self.lines.get(data, None)
-        del self.lines[data]
-        del self.slopes[data]
+        self.lines.pop(data, None)
+        self.slopes.pop(data, None)
         self.figure.marks = [mark for mark in self.figure.marks if mark != line]
 
     def _clear_lines(self):

--- a/cosmicds/viewers/cds_viewers.py
+++ b/cosmicds/viewers/cds_viewers.py
@@ -155,13 +155,16 @@ def cds_viewer(viewer_class, name, viewer_tools=[], label=None, state_cls=None):
                 return False
             return super().add_subset(subset)
 
+        # The argument here can be either a Data or Subset object
+        def layer_artist_for_data(self, data):
+            return next((a for a in self.layers if a.layer == data), None)
+
         def _update_xtick_values(self, values):
             self.axis_x.tick_values = values
         
         def _update_ytick_values(self, values):
             self.axis_y.tick_values = values
 
-        
     return CDSViewer
 
 


### PR DESCRIPTION
This PR adds a method to our viewer wrapper class that grabs the layer artist instance corresponding to a particular `Data` or `Subset` object.