### PR TITLE
Mid-beta fixes, part 1

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -246,7 +246,7 @@ export default {
           super();
           this.attachShadow({mode: "open"});
           this.input = document.createElement("input");
-          this.input.style.width = "35px";
+          this.input.style.width = "50px";
           this.input.onchange = this.handleChangeEvent.bind(this);
           this.shadowRoot.append(this.input);
 

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -245,7 +245,8 @@ export default {
         constructor() {
           super();
           this.attachShadow({mode: "open"});
-          this.input = document.createElement('input');
+          this.input = document.createElement("input");
+          this.input.style.width = "35px";
           this.input.onchange = this.handleChangeEvent.bind(this);
           this.shadowRoot.append(this.input);
 

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+from math import log10
 
 from astropy.modeling import models, fitting
 from bqplot.marks import Lines
@@ -278,3 +279,13 @@ def debounce(wait):
         return debounced
 
     return decorator
+
+def frexp10(x):
+    """
+    Find the mantissa and exponent of a value in base 10.
+
+    TODO: JC added this quickly mid-Hubble beta. Are there possible improvements?
+    """
+    exp = int(log10(x))
+    mantissa = x / (10 ** exp)
+    return mantissa, exp

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -280,12 +280,17 @@ def debounce(wait):
 
     return decorator
 
-def frexp10(x):
+def frexp10(x, normed=False):
     """
     Find the mantissa and exponent of a value in base 10.
 
+    If normed is True, the mantissa is fractional, while it is between 0 and 10 if normed is False.
+    Example:
+        normed: 0.5 * 10^5
+        non-normed: 5 * 10^4
+
     TODO: JC added this quickly mid-Hubble beta. Are there possible improvements?
     """
-    exp = int(log10(x))
+    exp = int(log10(x)) + int(normed)
     mantissa = x / (10 ** exp)
     return mantissa, exp

--- a/cosmicds/viewers/cds_viewers.py
+++ b/cosmicds/viewers/cds_viewers.py
@@ -17,7 +17,7 @@ def cds_viewer_state(state_class):
 
     class CDSViewerState(state_class):
 
-        TICK_SPACINGS = [1, 0.75, 0.5, 0.4, 0.3, 0.25, 0.2, 0.1]
+        TICK_SPACINGS = [10, 7.5, 5, 4, 3, 2.5, 2, 1]
 
         xtick_values = CallbackProperty([])
         ytick_values = CallbackProperty([])
@@ -31,7 +31,7 @@ def cds_viewer_state(state_class):
         @classmethod
         def best_spacing_frac(cls, frac):
             default = (-1, cls.TICK_SPACINGS[-1])
-            index, fless = next(((i, t) for i, t in enumerate(cls.TICK_SPACINGS) if frac > t), default)
+            index, fless = next(((i, t) for i, t in enumerate(cls.TICK_SPACINGS) if frac >= t), default)
             fmore = cls.TICK_SPACINGS[index - 1]
             dist_less = abs(frac - fless)
             dist_more = abs(frac - fmore)

--- a/cosmicds/viewers/cds_viewers.py
+++ b/cosmicds/viewers/cds_viewers.py
@@ -26,7 +26,7 @@ def cds_viewer_state(state_class):
         def tick_spacing(naive_spacing):
             mantissa, exp = frexp10(naive_spacing)
             frac = CDSViewerState.best_spacing_frac(mantissa)
-            return frac * (10 ** exp)
+            return round(frac * (10 ** exp))
 
         @classmethod
         def best_spacing_frac(cls, frac):


### PR DESCRIPTION
This PR makes a couple of fixes to issue that we had noticed. In particular:

* The width of our custom input elements is set to 35 pixels.
* The automatic tick spacing setting on viewers has been updated to be scale-invariant. We should now get something reasonable for the tick spacing regardless of how large the axis ranges get.