### PR TITLE
Add component for toggling layer visibility

### DIFF
--- a/cosmicds/components/layer_toggle/__init__.py
+++ b/cosmicds/components/layer_toggle/__init__.py
@@ -1,0 +1,1 @@
+from .layer_toggle import LayerToggle

--- a/cosmicds/components/layer_toggle/layer_toggle.py
+++ b/cosmicds/components/layer_toggle/layer_toggle.py
@@ -1,4 +1,5 @@
 from echo import delay_callback
+from echo.callback_container import CallbackContainer
 from ipyvuetify import VuetifyTemplate
 from traitlets import List, observe
 
@@ -15,8 +16,16 @@ class LayerToggle(VuetifyTemplate):
         self.viewer = viewer
         self.name_transform = LayerToggle._create_name_transform(names)
 
+        self._ignore_conditions = CallbackContainer()
+
         self._update_layers_from_viewer()
         self.viewer.state.add_callback('layers', self._update_layers_from_viewer)
+
+    def _ignore_layer(self, layer):
+        for cb in self._ignore_conditions:
+            if cb(layer):
+                return True
+        return False
 
     def _layer_data(self, layer):
         return {
@@ -24,16 +33,29 @@ class LayerToggle(VuetifyTemplate):
             "label": self.name_transform(layer.layer.label)
         }
 
+    @property
+    def watched_layers(self):
+        return [layer for layer in self.viewer.layers if not self._ignore_layer(layer)]
+
+    def add_ignore_condition(self, condition):
+        self._ignore_conditions.append(condition)
+        self._update_layers_from_viewer()
+
+    def remove_ignore_condition(self, condition):
+        self._ignore_conditions.remove(condition)
+        self._update_layers_from_viewer()
+
     def _update_layers_from_viewer(self, layers=None):
-        self.layers = [self._layer_data(layer) for layer in self.viewer.layers]
+        self.layers = [self._layer_data(layer) for layer in self.watched_layers]
         self.selected = [index for index, layer in enumerate(self.viewer.layers) if layer.state.visible]
 
     @observe('selected')
     def _on_selected_change(self, change):
         selected = change["new"]
         with delay_callback(self.viewer.state, 'layers'):
-            for index in range(len(self.layers)):
-                self.viewer.layers[index].state.visible = index in selected
+            for index, layer in enumerate(self.watched_layers):
+                if not self._ignore_layer(layer):
+                    layer.state.visible = index in selected
 
     @staticmethod
     def _create_name_transform(namer):

--- a/cosmicds/components/layer_toggle/layer_toggle.py
+++ b/cosmicds/components/layer_toggle/layer_toggle.py
@@ -1,0 +1,35 @@
+from echo import delay_callback
+from ipyvuetify import VuetifyTemplate
+from traitlets import List, observe
+
+from ...utils import load_template
+
+class LayerToggle(VuetifyTemplate):
+
+    template = load_template("layer_toggle.vue", __file__, traitlet=True).tag(sync=True)
+    layers = List().tag(sync=True)
+    selected = List().tag(sync=True)
+
+    def __init__(self, viewer, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.viewer = viewer
+
+        self._update_layers_from_viewer()
+        self.viewer.state.add_callback('layers', self._update_layers_from_viewer)
+
+    def _layer_data(self, layer):
+        return {
+            "color": layer.state.color,
+            "label": layer.layer.label
+        }
+
+    def _update_layers_from_viewer(self, layers=None):
+        self.layers = [self._layer_data(layer) for layer in self.viewer.layers]
+        self.selected = [index for index, layer in enumerate(self.viewer.layers) if layer.state.visible]
+
+    @observe('selected')
+    def _on_selected_change(self, change):
+        selected = change["new"]
+        with delay_callback(self.viewer.state, 'layers'):
+            for index in range(len(self.layers)):
+                self.viewer.layers[index].state.visible = index in selected

--- a/cosmicds/components/layer_toggle/layer_toggle.vue
+++ b/cosmicds/components/layer_toggle/layer_toggle.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-card
+    flat
+  >
+    TOGGLER
+    <v-list-item-group
+      multiple
+      v-model="selected"
+    >
+      <v-list-item
+        v-for="(layer, index) in layers"
+        :key="index"
+        :value="index"
+        inactive
+      >
+        <template v-slot:default="{ active }">
+          <v-list-item-content>
+            {{ layer.label }}
+          </v-list-item-content>
+
+          <v-list-item-action>
+            <v-checkbox
+              :input-value="active"
+              :color="layer.color"
+            ></v-checkbox>
+          </v-list-item-action>
+        </template>
+
+      </v-list-item>
+
+    </v-list-item-group>
+  </v-card>
+</template>

--- a/cosmicds/components/layer_toggle/layer_toggle.vue
+++ b/cosmicds/components/layer_toggle/layer_toggle.vue
@@ -2,7 +2,6 @@
   <v-card
     flat
   >
-    TOGGLER
     <v-list-item-group
       multiple
       v-model="selected"
@@ -22,7 +21,7 @@
             <v-checkbox
               :input-value="active"
               :color="layer.color"
-            ></v-checkbox>
+            />
           </v-list-item-action>
         </template>
 


### PR DESCRIPTION
This PR re-adds the layer-toggling functionality that we had in the original app architecture. This time the functionality is encapsulated in a component that can handle any of our viewers. Selecting/deselecting the relevant checkbox will show/hide the layer in the associated glue viewer. You just need to pass in the viewer, and there's also an optional argument `names` for a function or dictionary that tells how to map the labels of the glue layer to a display name. (If you don't give this, the layer labels themselves are used.) The component will automatically respond to changes in the glue viewer's list of layers.

For an example of using this in the Hubble story, see the [`toggle-layers` branch](https://github.com/Carifio24/hubbleds/tree/toggle-layers) of my HubbleDS repo. There I've added a `LayerToggle` component for the layer viewer in stage three.