### PR TITLE
Allow using viewers in multiple stages

### DIFF
--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -48,6 +48,7 @@ class Story(CDSState, HubMixin):
     total_score = CallbackProperty(0)
     has_scoring = CallbackProperty(True)
     responses = DictCallbackProperty()
+    viewers = DictCallbackProperty()
 
     def __init__(self, session, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -143,10 +144,16 @@ class Stage(TemplateMixin):
 
         self.stage_state = kwargs.get('stage_state', self._state_cls())
 
-    def add_viewer(self, cls, label, viewer_label=None, data=None, layout=ViewerLayout, show_toolbar=True):
-        viewer = self.app.new_data_viewer(cls, data=data, show=False)
+    def add_viewer(self, cls=None, label=None, viewer_label=None, data=None, layout=ViewerLayout, show_toolbar=True):
+        viewer = self.story_state.viewers.get(label, None)
+        if viewer is None:
+            # Don't use this as the default in `get`
+            # since it would get called whether the label is found or not
+            viewer = self.app.new_data_viewer(cls, data=data, show=False)
+            self.story_state.viewers[label] = viewer
         if viewer_label is not None:
             viewer.LABEL = viewer_label
+
         current_viewers = {k: v for k, v in self.viewers.items()}
         viewer_layout = layout(viewer, classes=[label])
         viewer_layout.show_toolbar = show_toolbar

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -48,12 +48,12 @@ class Story(CDSState, HubMixin):
     total_score = CallbackProperty(0)
     has_scoring = CallbackProperty(True)
     responses = DictCallbackProperty()
-    viewers = DictCallbackProperty()
 
     def __init__(self, session, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self._session = session
+        self.viewers = {}
 
         # When the step index or completion status changes, store that change
         # in the stage state
@@ -94,9 +94,6 @@ class Story(CDSState, HubMixin):
         self.stages[self.stage_index]['steps'][self.step_index][
             'completed'] = value
         self.write_to_db()
-
-    def viewers(self):
-        return self.app.viewers
 
     def _update_total_score(self, mc_scoring):
         self.total_score = sum(mc["score"] or 0 for stage in mc_scoring.values() for mc in stage.values())

--- a/cosmicds/registries.py
+++ b/cosmicds/registries.py
@@ -65,12 +65,12 @@ class StoryRegistry(UniqueDictRegistry):
         state = data["state"]
 
         if state is not None:
-            state["stages"] = { int(k) : v for k,v in state["stages"].items() }
+            state["stages"] = { int(k) : v for k, v in state["stages"].items() }
             story_state.update_from_dict(state)
 
         story_state.setup_for_student(app_state)
 
-        for k, v in story_entry['stages'].items():
+        for k, v in sorted(story_entry['stages'].items()):
             stage_cls = v['cls']
             stage_state = stage_cls._state_cls()
             if state is not None and k in state["stages"] and "state" in state["stages"][k]:


### PR DESCRIPTION
This PR adds functionality to allow using the same viewer in multiple stages. In particular, a viewer created in one stage can now be accessed in a later stage.

As an example, if I added a viewer with the label `"my-viewer"` in stage one, I could now add it to stage two by simply calling `add_viewer(label="my-viewer")`. It's important to note that these two widgets will then represent the same glue viewer instance - any changes (zooming, adding layers, etc) that a student makes in one widget will happen in both.

Behind the scenes, this is done by creating a `viewers` dictionary in the story state, which we use to hold a reference to every glue viewer added. When `add_viewer` is called in a stage, it first check to see if a viewer with the same label has already been added - if so, it uses that rather than create a new viewer. To ensure that this works properly, I've also made sure to sort the keys of `story_entry` during setup in the registry (so we know that the stages are set up in order).

I've created a [`share-viewers` branch](https://github.com/Carifio24/hubbleds/tree/share-viewers) for testing this out. It has a dummy extra stage which adds the layer viewer from stage three using this functionality.