### PR TITLE
Bump glue-core to 1.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ include_package_data = True
 install_requires = 
   numpy
   ipywidgets < 8
-  glue-core >= 1.4
+  glue-core >= 1.6
   glue-jupyter >= 0.12
   pywwt @ git+https://github.com/Carifio24/pywwt@prekdr
   astropy


### PR DESCRIPTION
`glue-core` version 1.6 was [just released](https://github.com/glue-viz/glue/releases/tag/v1.6.0), so this PR updates our pin to account for that. There are two main changes (both motivated by CosmicDS) that will be useful for us:

* The bug causing empty histogram layers to not be redrawn has been fixed
* We can now specify visual attributes (color, alpha, etc.) in the data collection's `new_subset` method, rather than create a subset and set styling right after. (This had previously been added for `new_subset_group`).