### PR TITLE
Add general layer toggle tool

### DIFF
--- a/cosmicds/tools/__init__.py
+++ b/cosmicds/tools/__init__.py
@@ -2,4 +2,5 @@ from .cds_home_tool import *
 from .info_tool import *
 from .line_draw_tool import *
 from .line_fit_tool import *
+from .toggle_layer_tool import *
 from .zoom_tools import *

--- a/cosmicds/tools/toggle_layer_tool.py
+++ b/cosmicds/tools/toggle_layer_tool.py
@@ -1,0 +1,29 @@
+from echo import CallbackProperty
+from glue.config import viewer_tool
+from glue.viewers.common.tool import Tool
+
+
+@viewer_tool
+class LayerToggleTool(Tool):
+    toggled_count = CallbackProperty(0)
+
+    tool_id = "cds:togglelayer"
+    action_text = "Toggle display of a given layer"
+    tool_tip = "Toggle display of data"
+    mdi_icon = "mdi-toggle-switch-outline"
+
+    def __init__(self, viewer, **kwargs):
+        super().__init__(viewer, **kwargs)
+        self.layer_to_toggle = None
+
+    def activate(self):
+        if self.layer_to_toggle is None:
+            return
+
+        # if we have no layers, don't do anything
+        if len(self.viewer.layers) > 0:
+            self.layer_to_toggle.state.visible = not self.layer_to_toggle.state.visible
+            self.toggled_count += 1
+    
+    def set_layer_to_toggle(self, layer):
+        self.layer_to_toggle = layer

--- a/cosmicds/tools/toggle_layer_tool.py
+++ b/cosmicds/tools/toggle_layer_tool.py
@@ -14,16 +14,16 @@ class LayerToggleTool(Tool):
 
     def __init__(self, viewer, **kwargs):
         super().__init__(viewer, **kwargs)
-        self.layer_to_toggle = None
+        self.layer = None
 
     def activate(self):
-        if self.layer_to_toggle is None:
+        if self.layer is None:
             return
 
         # if we have no layers, don't do anything
         if len(self.viewer.layers) > 0:
-            self.layer_to_toggle.state.visible = not self.layer_to_toggle.state.visible
+            self.layer.state.visible = not self.layer.state.visible
             self.toggled_count += 1
     
     def set_layer_to_toggle(self, layer):
-        self.layer_to_toggle = layer
+        self.layer = layer


### PR DESCRIPTION
This PR adds a generic layer-toggling tool. This is a pretty common operation that I suspect we'll want to use again in future tools, so I've extracted out what I think is the generic behavior from the Hubble class layer toggle. https://github.com/cosmicds/hubbleds/pull/104 makes that tool a subclass of this one.

Also, the current tool in the Hubble repo gets its layer by index in some cases. As we've seen, that can be a problematic approach. Thus, I modified the implementation here to avoid ever needing to rely on layer index.