### PR TITLE
Add CDSGlueState to wrap glue state objects

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -8,7 +8,7 @@ from echo import add_callback, CallbackProperty
 from glue.core import HubListener
 from glue.core.state_objects import State
 from glue_jupyter.app import JupyterApplication
-from glue_jupyter.state_traitlets_helpers import GlueState
+from cosmicds.cds_glue_state import CDSGlueState
 from ipyvuetify import VuetifyTemplate
 from ipywidgets import widget_serialization
 from traitlets import Dict, Bool, Int
@@ -32,11 +32,11 @@ class ApplicationState(State):
 
 class Application(VuetifyTemplate, HubListener):
     _metadata = Dict({"mount_id": "content"}).tag(sync=True)
-    story_state = GlueState().tag(sync=True)
+    story_state = CDSGlueState().tag(sync=True)
     template = load_template("app.vue", __file__, traitlet=True).tag(sync=True)
     drawer = Bool(True).tag(sync=True)
     vue_components = Dict().tag(sync=True, **widget_serialization)
-    app_state = GlueState().tag(sync=True)
+    app_state = CDSGlueState().tag(sync=True)
     student_id = Int(0).tag(sync=True)
 
     def __init__(self, story, *args, **kwargs):

--- a/cosmicds/cds_glue_state.py
+++ b/cosmicds/cds_glue_state.py
@@ -1,0 +1,12 @@
+from glue_jupyter.state_traitlets_helpers import GlueState
+from traitlets.utils.bunch import Bunch
+
+class CDSGlueState(GlueState):
+
+    def on_state_change(self, *args, obj=None, **kwargs):
+        if self._block_on_state_change:
+            return
+        obj.notify_change(Bunch({'name': self.name,
+                                 'type': 'change',
+                                 'value': self.get(obj),
+                                 'new': self.get(obj)}))

--- a/cosmicds/components/generic_state_component/generic_state_component.py
+++ b/cosmicds/components/generic_state_component/generic_state_component.py
@@ -1,13 +1,13 @@
-from glue_jupyter.state_traitlets_helpers import GlueState
 from ipyvuetify import VuetifyTemplate
 from traitlets import Unicode
 
+from cosmicds.cds_glue_state import CDSGlueState
 from cosmicds.utils import load_template
 
 class GenericStateComponent(VuetifyTemplate):
 
     template = Unicode().tag(sync=True)
-    state = GlueState().tag(sync=True)
+    state = CDSGlueState().tag(sync=True)
 
     def __init__(self, filename, path, state, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -1,9 +1,9 @@
-from glue_jupyter.state_traitlets_helpers import GlueState
 from ipywidgets import widget_serialization
 from traitlets import Dict, Unicode
 from cosmicds.components.viewer_layout import ViewerLayout
 from cosmicds.events import WriteToDatabaseMessage
 
+from cosmicds.cds_glue_state import CDSGlueState
 from cosmicds.mixins import TemplateMixin, HubMixin
 from cosmicds.utils import debounce
 from glue.core import Data
@@ -120,9 +120,9 @@ class Story(CDSState, HubMixin):
 
 class Stage(TemplateMixin):
     template = Unicode().tag(sync=True)
-    story_state = GlueState().tag(sync=True)
-    stage_state = GlueState().tag(sync=True)
-    app_state = GlueState().tag(sync=True)
+    story_state = CDSGlueState().tag(sync=True)
+    stage_state = CDSGlueState().tag(sync=True)
+    app_state = CDSGlueState().tag(sync=True)
     stage_icon = Unicode().tag(sync=True)
     title = Unicode().tag(sync=True)
     subtitle = Unicode().tag(sync=True)


### PR DESCRIPTION
This PR adds a `CDSGlueState` wrapper class for the `GlueState` traitlet. The main use for this is to override the `on_state_change` method to match the previous implementation in `GlueState`. This serves as an implementation of option 2 in #176. If things change on that front, we can re-evaluate whether we need this or not.