### PR TITLE
Sorting and setting order of layers in toggler component

### DIFF
--- a/cosmicds/components/layer_toggle/layer_toggle.py
+++ b/cosmicds/components/layer_toggle/layer_toggle.py
@@ -38,7 +38,7 @@ class LayerToggle(VuetifyTemplate):
         try:
             return layers.index(layer)
         except Exception:
-            return -1
+            return len(self.watched_layers) + 1
 
     def set_layer_order(self, layers):
         def sort_key(layer):

--- a/cosmicds/components/layer_toggle/layer_toggle.py
+++ b/cosmicds/components/layer_toggle/layer_toggle.py
@@ -36,9 +36,10 @@ class LayerToggle(VuetifyTemplate):
 
     def _layer_index(self, layers, layer):
         try:
-            return layers.index(layer)
-        except Exception:
-            return len(self.watched_layers) + 1
+            index = layers.index(layer)
+            return index
+        except ValueError:
+            return len(layers) + 1
 
     def set_layer_order(self, layers):
         def sort_key(layer):

--- a/cosmicds/components/layer_toggle/layer_toggle.py
+++ b/cosmicds/components/layer_toggle/layer_toggle.py
@@ -11,10 +11,11 @@ class LayerToggle(VuetifyTemplate):
     layers = List().tag(sync=True)
     selected = List().tag(sync=True)
 
-    def __init__(self, viewer, names=None, *args, **kwargs):
+    def __init__(self, viewer, names=None, sort=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.viewer = viewer
         self.name_transform = LayerToggle._create_name_transform(names)
+        self.sort = sort
 
         self._ignore_conditions = CallbackContainer()
 
@@ -46,7 +47,7 @@ class LayerToggle(VuetifyTemplate):
         self._update_layers_from_viewer()
 
     def _update_layers_from_viewer(self, layers=None):
-        self.layers = [self._layer_data(layer) for layer in self.watched_layers]
+        self.layers = sorted([self._layer_data(layer) for layer in self.watched_layers], key=self.sort)
         self.selected = [index for index, layer in enumerate(self.viewer.layers) if layer.state.visible]
 
     @observe('selected')

--- a/cosmicds/components/layer_toggle/layer_toggle.py
+++ b/cosmicds/components/layer_toggle/layer_toggle.py
@@ -15,7 +15,7 @@ class LayerToggle(VuetifyTemplate):
         super().__init__(*args, **kwargs)
         self.viewer = viewer
         self.name_transform = LayerToggle._create_name_transform(names)
-        self.sort = sort
+        self.sort = sort or (lambda layer: layer.state.zorder)
 
         self._ignore_conditions = CallbackContainer()
 
@@ -34,9 +34,24 @@ class LayerToggle(VuetifyTemplate):
             "label": self.name_transform(layer.layer.label)
         }
 
+    def _layer_index(self, layers, layer):
+        try:
+            return layers.index(layer)
+        except Exception:
+            return -1
+
+    def set_layer_order(self, layers):
+        def sort_key(layer):
+            return (self._layer_index(layers, layer), layer.state.zorder)
+        self.sort_by(sort_key)
+
+    def sort_by(self, sort):
+        self.sort = sort
+        self._update_layers_from_viewer()  
+
     @property
     def watched_layers(self):
-        return [layer for layer in self.viewer.layers if not self._ignore_layer(layer)]
+        return sorted([layer for layer in self.viewer.layers if not self._ignore_layer(layer)], key=self.sort)
 
     def add_ignore_condition(self, condition):
         self._ignore_conditions.append(condition)
@@ -47,8 +62,9 @@ class LayerToggle(VuetifyTemplate):
         self._update_layers_from_viewer()
 
     def _update_layers_from_viewer(self, layers=None):
-        self.layers = sorted([self._layer_data(layer) for layer in self.watched_layers], key=self.sort)
-        self.selected = [index for index, layer in enumerate(self.viewer.layers) if layer.state.visible]
+        watched = self.watched_layers
+        self.layers = [self._layer_data(layer) for layer in watched]
+        self.selected = [index for index, layer in enumerate(watched) if layer.state.visible]
 
     @observe('selected')
     def _on_selected_change(self, change):


### PR DESCRIPTION
This PR adds sorting functionality to the layer toggling component introduced in #172. This can be done in two ways:

* The component's `sort_by` method. This method accepts a function whose argument should be a layer, and should return the value that determines the order of the layer in the component (by default, this is the layer state's z-order).
* The component's `set_layer_order` method. This method's argument should be a list of layer artists. The layers will be sorted by their index in this list. Any layers that aren't in the given list will be sorted to the end.

The [`layer-toggler-order` branch](https://github.com/Carifio24/hubbleds/tree/layer-toggler-order) on my fork has an example of this in stage three - it's very similar to the example used for testing #172, just also using this new functionality.