### PR TITLE
Add dotplot viewer

### DIFF
--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -38,12 +38,15 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
             x_range = self._viewer_state.x_max - self._viewer_state.x_min
             y_range = self._viewer_state.y_max - self._viewer_state.y_min
             n = len(self.bars.x)
+            
 
+            # JC: As of right now, there's a bit of trickery here
+            # We're assuming that the viewer has its default height of 400px
+            # I reverse-engineered the formula relating size (the setting we give to bqplot)
+            # and the ratio (viewer pixel height / data y range), which is what we want the pixel height to be.
             ratio = 400 / y_range
             factor = 0.785
             size = floor(factor * (ratio ** 2))
-            #size = round(self.bins[1] - self.bins[0])
-            print(f"Size: {size}")
             self.bars.default_size = size
 
             skew = min(x_range / y_range, 1)

--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -1,0 +1,115 @@
+from echo.core import add_callback
+from glue_jupyter.bqplot.histogram.layer_artist import BqplotHistogramLayerArtist
+from glue_jupyter.link import dlink, link
+from bqplot import ScatterGL, Scatter
+from numpy import inf
+from math import floor
+from glue.utils import color2hex
+
+
+class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
+
+    def __init__(self, view, viewer_state, layer_state=None, layer=None):
+
+        super(BqplotHistogramLayerArtist, self).__init__(viewer_state,
+                                                         layer_state=layer_state, layer=layer)
+
+        self.view = view
+
+        self.bars = Scatter(scales=self.view.scales, x=[0, 1], y=[0, 1], marker='circle')
+
+        self.view.figure.marks = list(self.view.figure.marks) + [self.bars]
+
+        dlink((self.state, 'color'), (self.bars, 'colors'), lambda x: [color2hex(x)])
+        dlink((self.state, 'alpha'), (self.bars, 'opacities'), lambda x: [x])
+
+        self._viewer_state.add_global_callback(self._update_histogram)
+        self.state.add_global_callback(self._update_histogram)
+        self.bins = None
+
+        link((self.state, 'visible'), (self.bars, 'visible'))
+
+        add_callback(self._viewer_state, 'x_min', self._update_size)
+        add_callback(self._viewer_state, 'x_max', self._update_size)
+
+    def _update_size(self, arg=None):
+        print(self._viewer_state.y_min, self._viewer_state.y_max)
+        if self._viewer_state.y_max is not None and self._viewer_state.y_min is not None:
+            x_range = self._viewer_state.x_max - self._viewer_state.x_min
+            y_range = self._viewer_state.y_max - self._viewer_state.y_min
+            n = len(self.bars.x)
+
+            ratio = 400 / y_range
+            factor = 0.785
+            size = floor(factor * (ratio ** 2))
+            #size = round(self.bins[1] - self.bins[0])
+            print(f"Size: {size}")
+            self.bars.default_size = size
+
+            skew = min(x_range / y_range, 1)
+            self.bars.default_skew = skew
+
+    def _scale_histogram(self):
+        # TODO: comes from glue/viewers/histogram/layer_artist.py
+        if self.bins is None:
+            return  # can happen when the subset is empty
+
+        if self.bins.size == 0 or self.hist_unscaled.sum() == 0:
+            return
+
+        self.hist = self.hist_unscaled.astype(float)
+        dx = self.bins[1] - self.bins[0]
+
+        if self._viewer_state.cumulative:
+            self.hist = self.hist.cumsum()
+            if self._viewer_state.normalize:
+                self.hist /= self.hist.max()
+        elif self._viewer_state.normalize:
+            self.hist /= (self.hist.sum() * dx)
+
+        # TODO this won't work for log ...
+        centers = (self.bins[:-1] + self.bins[1:]) / 2
+        assert len(centers) == len(self.hist)
+
+        x, y = [], []
+        counts = self.hist.astype(int)
+        for i in range(self.bins.size - 1):
+            x_i = (self.bins[i] + self.bins[i+1])/2
+            y_i = range(1, counts[i] + 1)
+            x.extend([x_i] * counts[i])
+            y.extend(y_i)
+     
+        self.bars.x = x
+        self.bars.y = y
+        self._update_size()
+
+        # We have to do the following to make sure that we reset the y_max as
+        # needed. We can't simply reset based on the maximum for this layer
+        # because other layers might have other values, and we also can't do:
+        #
+        #   self._viewer_state.y_max = max(self._viewer_state.y_max, result[0].max())
+        #
+        # because this would never allow y_max to get smaller.
+
+        self.state._y_max = self.hist.max()
+        if self._viewer_state.y_log:
+            self.state._y_max *= 2
+        else:
+            self.state._y_max *= 1.2
+
+        if self._viewer_state.y_log:
+            self.state._y_min = self.hist[self.hist > 0].min() / 10
+        else:
+            self.state._y_min = 0
+
+        largest_y_max = max(getattr(layer, '_y_max', 0)
+                            for layer in self._viewer_state.layers)
+        if largest_y_max != self._viewer_state.y_max:
+            self._viewer_state.y_max = largest_y_max
+
+        smallest_y_min = min(getattr(layer, '_y_min', inf)
+                             for layer in self._viewer_state.layers)
+        if smallest_y_min != self._viewer_state.y_min:
+            self._viewer_state.y_min = smallest_y_min
+
+        self.redraw()

--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -41,15 +41,16 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
             y_range = self._viewer_state.y_max - self._viewer_state.y_min
 
             # The default_size parameter in bqplot specifies the area of the mark in pixels
-            # but we know what height (i.e. diameter) we want
+            # but we know what pixel height (i.e. diameter) we want
             # so the size should be (pi / 4) * height ^ 2
-            height = (self._viewer_state.viewer_height + self.view.figure.fig_margin["top"]) / y_range
+            pixel_height = (self._viewer_state.viewer_height + self.view.figure.fig_margin["top"]) / y_range
+
 
             # Shrink and scale height to add a bit of space
             spacing = 1
-            scaling = 0.85
-            size = floor((pi / 4) * ((scaling * height - spacing) ** 2))
-            
+            scaling = 0.7
+            size = floor((pi / 4) * ((scaling * pixel_height - spacing) ** 2))
+            size = max(size, 1)
             self.bars.default_size = size
 
     def _scale_histogram(self):
@@ -57,7 +58,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
         if self.bins is None:
             return  # can happen when the subset is empty
 
-        if self.bins.size == 0 or self.hist_unscaled.sum() == 0:
+        if self.bins.size == 0:
             return
 
         self.hist = self.hist_unscaled.astype(float)

--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -1,10 +1,13 @@
+from math import floor, pi
+
 from echo.core import add_callback
+from glue.utils import color2hex
 from glue_jupyter.bqplot.histogram.layer_artist import BqplotHistogramLayerArtist
 from glue_jupyter.link import dlink, link
-from bqplot import ScatterGL, Scatter
+
+from bqplot import ScatterGL
 from numpy import inf
-from math import floor, pi
-from glue.utils import color2hex
+
 
 
 class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
@@ -16,7 +19,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
 
         self.view = view
 
-        self.bars = Scatter(scales=self.view.scales, x=[0, 1], y=[0, 1], marker='circle')
+        self.bars = ScatterGL(scales=self.view.scales, x=[0, 1], y=[0, 1], marker='circle')
 
         self.view.figure.marks = list(self.view.figure.marks) + [self.bars]
 

--- a/cosmicds/viewers/dotplot/state.py
+++ b/cosmicds/viewers/dotplot/state.py
@@ -1,8 +1,10 @@
-from echo.core import add_callback, delay_callback
+from echo.core import add_callback, delay_callback, CallbackProperty
 from glue.viewers.histogram.state import HistogramViewerState
 
 
 class DotPlotViewerState(HistogramViewerState):
+
+    viewer_height = CallbackProperty(400) # in pixels
 
     def __init__(self, **kwargs):
         super(DotPlotViewerState, self).__init__(**kwargs)

--- a/cosmicds/viewers/dotplot/state.py
+++ b/cosmicds/viewers/dotplot/state.py
@@ -1,0 +1,15 @@
+from echo.core import add_callback, delay_callback
+from glue.viewers.histogram.state import HistogramViewerState
+
+
+class DotPlotViewerState(HistogramViewerState):
+
+    def __init__(self, **kwargs):
+        super(DotPlotViewerState, self).__init__(**kwargs)
+        add_callback(self, 'x_min', self._update_bins)
+        add_callback(self, 'x_max', self._update_bins)
+
+    def _update_bins(self, arg=None):
+        with delay_callback(self, 'hist_x_min', 'hist_x_max'):
+            self.hist_x_min = self.x_min
+            self.hist_x_max = self.x_max

--- a/cosmicds/viewers/dotplot/viewer.py
+++ b/cosmicds/viewers/dotplot/viewer.py
@@ -10,7 +10,7 @@ class BqplotDotPlotView(BqplotHistogramView):
     _data_artist_cls = BqplotDotPlotLayerArtist
     _subset_artist_cls = BqplotDotPlotLayerArtist
 
-    tools = BqplotHistogramView.tools + ["bqplot:xzoom"]
+    tools = ["bqplot:home", "bqplot:xzoom"]
 
     def __init__(self, session, state=None):
         super(BqplotDotPlotView, self).__init__(session, state=state)

--- a/cosmicds/viewers/dotplot/viewer.py
+++ b/cosmicds/viewers/dotplot/viewer.py
@@ -11,3 +11,17 @@ class BqplotDotPlotView(BqplotHistogramView):
     _subset_artist_cls = BqplotDotPlotLayerArtist
 
     tools = BqplotHistogramView.tools + ["bqplot:xzoom"]
+
+    def __init__(self, session, state=None):
+        super(BqplotDotPlotView, self).__init__(session, state=state)
+        self.figure.layout.observe(self._update_height, names='height')
+
+    def _update_height(self, change):
+        # For now, we just assume that the height is entered in pixels
+        # e.g. "300px"
+        # TODO: Handle other height specifications
+        height = change["new"]
+        if height.endswith("px"):
+            height = int(height[:-2])
+            height -= self.figure.fig_margin["bottom"]
+            self.state.viewer_height = height

--- a/cosmicds/viewers/dotplot/viewer.py
+++ b/cosmicds/viewers/dotplot/viewer.py
@@ -1,0 +1,13 @@
+from glue_jupyter.bqplot.histogram import BqplotHistogramView
+from .layer_artist import BqplotDotPlotLayerArtist
+from .state import DotPlotViewerState
+
+class BqplotDotPlotView(BqplotHistogramView):
+
+    LABEL = "Dot Plot Viewer"
+
+    _state_cls = DotPlotViewerState
+    _data_artist_cls = BqplotDotPlotLayerArtist
+    _subset_artist_cls = BqplotDotPlotLayerArtist
+
+    tools = BqplotHistogramView.tools + ["bqplot:xzoom"]

--- a/cosmicds/viewers/dotplot/viewer.py
+++ b/cosmicds/viewers/dotplot/viewer.py
@@ -1,6 +1,7 @@
 from glue_jupyter.bqplot.histogram import BqplotHistogramView
 from .layer_artist import BqplotDotPlotLayerArtist
 from .state import DotPlotViewerState
+from ipywidgets import DOMWidget
 
 class BqplotDotPlotView(BqplotHistogramView):
 
@@ -10,7 +11,7 @@ class BqplotDotPlotView(BqplotHistogramView):
     _data_artist_cls = BqplotDotPlotLayerArtist
     _subset_artist_cls = BqplotDotPlotLayerArtist
 
-    tools = ["bqplot:home", "bqplot:xzoom"]
+    tools = BqplotHistogramView.tools + ["bqplot:xzoom"]
 
     def __init__(self, session, state=None):
         super(BqplotDotPlotView, self).__init__(session, state=state)
@@ -21,7 +22,7 @@ class BqplotDotPlotView(BqplotHistogramView):
         # e.g. "300px"
         # TODO: Handle other height specifications
         height = change["new"]
-        if height.endswith("px"):
+        if height is not None and height.endswith("px"):
             height = int(height[:-2])
             height -= self.figure.fig_margin["bottom"]
             self.state.viewer_height = height


### PR DESCRIPTION
This PR adds a basic dot plot viewer for drawing dot plots. This is an adapted version of the histogram viewer with a few extra wrinkles to make things work.

A few notes:
* The layer artist of this viewer is a subclass of the bqplot histogram layer artist. The main differences are that we overwrite the constructor and `_scale_histogram` methods to account for the fact that we're using the histogram values to construct `ScatterGL` rather than `Bar` marks. Other than the different mark logic, these implementations are largely the same as the superclass ones.
  - If there's interest on the glue side, I think this is something that could be added as an option in the glue-jupyter histogram viewer. If that ends up being the case, this would just be functionality added to the existing layer artist, rather than requiring a subclass. But that's something we can think about later.
* The main challenge here was getting the dots to draw nicely. bqplot allows setting individual sizes, or one default size, on a `Scatter` mark. Since we want every dot the same size, this implementation sets the `default_size` attribute.
  - `default_size` is specified in pixels, and in particular it specifies the area of the mark. Since we're sizing our circles based on the height of the viewer, the method that I've used to set the size is
    * Find the diameter d, in pixels, that we want by dividing the relevant figure height by our y range (y_max - y_min)
    * Convert this to an area via f * (pi/4) * (d - s)^2, where f and s are factors to add some spacing between dots (rather than have them be exactly tangent).
- Figure height was also a bit tricky. To make this work, we have a `viewer_height` member value in the viewer state, which by default is set to 410px, the default size of the relevant part of the figure. If we change the viewer height Python-side, by using `viewer.figure.layout.height = '<some-number>px`, our viewer state will listen to this update and the dots will be resized accordingly. In the unlikely case that we use some CSS or JS to change the figure height, we'll have to manually invoke this somewhere in the Python code.

Feel free to experiment with the dot sizing settings, which are set [here](https://github.com/Carifio24/cosmicds/blob/dotplot/cosmicds/viewers/dotplot/layer_artist.py#L49). I picked scaling and spacing values that I thought worked well, but I'm open to suggestions.

I've [uploaded a notebook](https://gist.github.com/Carifio24/551162e165bb72bfc3e34bdd410bd2f4) for experimenting with this, which also has an example of what a subset highlighting a particular student's data will look like (this student has two data points in the dataset). If you don't already have it, the necessary data file is in the linked gist as well.