### PR TITLE
Change scaffold-alert header text to be computed

### DIFF
--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -12,7 +12,7 @@
         <h3
           class="mb-4"
         >
-          {{ headerText instanceof Function ? headerText() : headerText }}
+          {{ header }}
         </h3>
       </v-col>
       <v-col
@@ -96,6 +96,13 @@ module.exports = {
   computed: {
     advance() {
       return !this.canAdvance || this.canAdvance(this.state)
+    },
+    header() {
+      if (this.headerText instanceof Function) {
+        return this.headerText(this.state);
+      } else {
+        return this.headerText;
+      }
     }
   }
 };


### PR DESCRIPTION
This PR contains a small change to the `scaffold-alert` component that makes the header text a computed value, rather than using inline template logic. This also makes `headerText`, when it's a function, be able to call the state as an argument.