### PR TITLE
Speech synthesis for v-icons and MathJax

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -348,8 +348,16 @@ export default {
         }
       },
       options: {
+        menuOptions: {
+          settings: {
+            assistiveMml: true
+          }
+        },
         a11y: {
-          speech: true
+          speech: true,
+          sre: {
+            speech: 'deep'
+          }
         }
       }
     };

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -303,7 +303,7 @@ export default {
 
     // Colors that seem to work consistently are in Section "4.3. Colors via svgnames option," pg 42 of this doc: https://ctan.math.washington.edu/tex-archive/macros/latex/contrib/xcolor/xcolor.pdf
     window.MathJax = {
-      loader: {load: ['[tex]/color', '[tex]/bbox']},
+      loader: {load: ['[tex]/color', '[tex]/bbox', 'a11y/semantic-enrich']},
       tex: {
         packages: {'[+]': ['input', 'color', 'bbox']},
         color: {
@@ -346,7 +346,12 @@ export default {
 
           MathJax.startup.defaultReady();
         }
-      }, 
+      },
+      options: {
+        a11y: {
+          speech: true
+        }
+      }
     };
 
     // Grab MathJax itself

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -53,7 +53,7 @@ module.exports = {
         } else {
           const txt = document.createElement("text");
           const cls = classes[0];
-          txt.textContent = `the ${cls.slice(mdiPrefix.length).replace("-", " ")} button`;
+          txt.textContent = cls.slice(mdiPrefix.length).replace("-", " ");
           icon.parentNode.replaceChild(txt, icon);
         }
       });

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -44,20 +44,33 @@ module.exports = {
 
       // Replace any MDI icons with text representing their name
       const clone = element.cloneNode(true);
-      const mdiStart = "mdi-";
-      const icons = clone.querySelectorAll(`i[class*='${mdiStart}']`);
+      const mdiPrefix = "mdi-";
+      const icons = clone.querySelectorAll(`i[class*='${mdiPrefix}']`);
       icons.forEach(icon => {
-        const classes = [...icon.classList].filter(cls => cls.startsWith(mdiStart));
+        const classes = [...icon.classList].filter(cls => cls.startsWith(mdiPrefix));
         if (classes.length === 0) {
           icon.remove();
         } else {
           const txt = document.createElement("text");
           const cls = classes[0];
-          txt.textContent = `the ${cls.slice(mdiStart.length).replace("-", " ")} button`;
+          txt.textContent = `the ${cls.slice(mdiPrefix.length).replace("-", " ")} button`;
           icon.parentNode.replaceChild(txt, icon);
         }
       });
 
+      // Replace any MathJax with its semantic speech text
+      const mathJax = clone.querySelectorAll(".JaxEquation");
+      const speechTextAttribute = "data-semantic-speech";
+      mathJax.forEach(equation => {
+        const speechElement = equation.querySelector(`[${speechTextAttribute}]`);
+        if (speechElement) {
+          const txt = document.createElement("text");
+          txt.textContent = speechElement.getAttribute(speechTextAttribute);
+          equation.parentNode.replaceChild(txt, equation);
+        } else {
+          equation.remove();
+        }
+      });
 
       return clone.textContent
 

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -15,7 +15,7 @@ module.exports = {
   props: {
     selectors: {
       type: Array,
-      default: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', ':has(> mjx-container)']
+      default: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', ':not(mjx-assistive-mml) > mjx-container']
     },
     stopOnClose: {
       type: Boolean,
@@ -54,25 +54,23 @@ module.exports = {
           const txt = document.createElement("text");
           const cls = classes[0];
           txt.textContent = cls.slice(mdiPrefix.length).replace("-", " ");
-          icon.parentNode.replaceChild(txt, icon);
+          icon.parentNode?.replaceChild(txt, icon);
         }
       });
 
       // Replace any MathJax with its semantic speech text
-      const mathJax = clone.querySelectorAll("mjx-container");
-      const speechTextAttribute = "data-semantic-speech";
-      mathJax.forEach(jax => {
-        const speechElement = jax.querySelector(`[${speechTextAttribute}]`);
-        if (speechElement) {
+      if (clone.tagName === "mjx-container") {
+        const speechText = clone.getAttribute("aria-label");
+        if (speechText) {
           const txt = document.createElement("text");
-          txt.textContent = speechElement.getAttribute(speechTextAttribute);
-          jax.parentNode.replaceChild(txt, jax);
+          txt.textContent = speechText;
+          clone.parentNode?.replaceChild(txt, clone);
         } else {
-          jax.remove();
+          clone.remove();
         }
-      });
+      }
 
-      return clone.textContent
+      return clone.textContent.trim();
 
     },
     makeUtterance(text) {

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -41,7 +41,26 @@ module.exports = {
   },
   methods: {
     elementText(element) {
-      return element.textContent;
+
+      // Replace any MDI icons with text representing their name
+      const clone = element.cloneNode(true);
+      const mdiStart = "mdi-";
+      const icons = clone.querySelectorAll(`i[class*='${mdiStart}']`);
+      icons.forEach(icon => {
+        const classes = [...icon.classList].filter(cls => cls.startsWith(mdiStart));
+        if (classes.length === 0) {
+          icon.remove();
+        } else {
+          const txt = document.createElement("text");
+          const cls = classes[0];
+          txt.textContent = `the ${cls.slice(mdiStart.length).replace("-", " ")} button`;
+          icon.parentNode.replaceChild(txt, icon);
+        }
+      });
+
+
+      return clone.textContent
+
     },
     makeUtterance(text) {
       const utterance = new SpeechSynthesisUtterance(text);

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -45,7 +45,7 @@ module.exports = {
       // Replace any MDI icons with text representing their name
       const clone = element.cloneNode(true);
       const mdiPrefix = "mdi-";
-      const icons = clone.querySelectorAll(`i[class*='${mdiPrefix}']`);
+      const icons = clone.querySelectorAll(`[class*='${mdiPrefix}']`);
       icons.forEach(icon => {
         const classes = [...icon.classList].filter(cls => cls.startsWith(mdiPrefix));
         if (classes.length === 0) {

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -15,7 +15,7 @@ module.exports = {
   props: {
     selectors: {
       type: Array,
-      default: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p']
+      default: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', ':has(> mjx-container)']
     },
     stopOnClose: {
       type: Boolean,
@@ -59,16 +59,16 @@ module.exports = {
       });
 
       // Replace any MathJax with its semantic speech text
-      const mathJax = clone.querySelectorAll(".JaxEquation");
+      const mathJax = clone.querySelectorAll("mjx-container");
       const speechTextAttribute = "data-semantic-speech";
-      mathJax.forEach(equation => {
-        const speechElement = equation.querySelector(`[${speechTextAttribute}]`);
+      mathJax.forEach(jax => {
+        const speechElement = jax.querySelector(`[${speechTextAttribute}]`);
         if (speechElement) {
           const txt = document.createElement("text");
           txt.textContent = speechElement.getAttribute(speechTextAttribute);
-          equation.parentNode.replaceChild(txt, equation);
+          jax.parentNode.replaceChild(txt, jax);
         } else {
-          equation.remove();
+          jax.remove();
         }
       });
 


### PR DESCRIPTION
This PR updates the speech synthesis component to handle our icons as well as MathJax. For both cases, the basic idea is the same: for each element that get matched by the selectors, we deep-clone that element and replace any icons or MathJax with a `text` element with the text that we want to use. Then we can just grab the `textContent` of the cloned element, like we were doing before.

For icons, we use that fact that `<v-icon>some-icon-name</v-icon>` ends up in the DOM as `<i class="... some-icon-name ..."></i>` (or `<button class="... some-icon-name"></button>` for an icon button). Since we're using MDI icons, this means that we can find the icon name by looking for a class that starts with "mdi-". We can then use the rest of the class name, with hyphens replaced by spaced, as the relevant text.

MathJax is a bit trickier. MathJax _can_ automatically generate speech strings for its output, which is then stored in the `aria-label` attribute of one of the `mjx-container`. From what I've seen, these speech strings aren't perfect, but they should get the job done as this isn't something we have the bandwidth to do ourselves. The issue is that a user has to opt-in (via a context menu that can be shown by right-clicking any MathJax) to having the speech text be generated. I've tried a few things but can't get this option to automatically be activated ([relevant SO question](https://stackoverflow.com/questions/60688026/how-to-activate-mathjax-accessibility-by-default)). Worst case, we can have a small dialog showing a user how to do this.

Since MathJax is generally something we want to read, I've also added a new default selector for that.