### PR TITLE
Disable headers by default

### DIFF
--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -8,6 +8,7 @@
     <v-row>
       <v-col
         cols="10"
+        v-if="showHeader"
       >
         <h3
           class="mb-4"
@@ -23,6 +24,7 @@
     </v-row>
     <slot></slot>
     <v-divider
+      v-if="showHeader"
       class="my-4"
     >
     </v-divider>
@@ -80,7 +82,7 @@ module.exports = {
     },
     headerText: {
       type: [String, Function],
-      required: true
+      default: null
     },
     nextText: {
       type: String,
@@ -96,6 +98,9 @@ module.exports = {
   computed: {
     advance() {
       return !this.canAdvance || this.canAdvance(this.state)
+    },
+    showHeader() {
+      return !!this.headerText
     }
   }
 };

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -5,10 +5,9 @@
     max-width="800"
     elevation="6"
   >
-    <v-row>
+    <v-row v-if="showHeader">
       <v-col
         cols="10"
-        v-if="showHeader"
       >
         <h3
           class="mb-4"
@@ -32,7 +31,14 @@
       align="center"
       no-gutters
     >
-      <v-col>
+      <v-col
+        v-if="!showHeader"
+        cols="1"
+        class="mx-2"
+      >
+        <speech-synthesizer/>
+      </v-col>
+      <v-col cols="5">
         <v-btn
           v-if="allowBack"  
           class="black--text"
@@ -50,6 +56,7 @@
         </span>
       </v-col>
       <v-col
+        cols="5"
         class="text-right"
       >
         <v-spacer></v-spacer>
@@ -97,10 +104,10 @@ module.exports = {
   },
   computed: {
     advance() {
-      return !this.canAdvance || this.canAdvance(this.state)
+      return !this.canAdvance || this.canAdvance(this.state);
     },
     showHeader() {
-      return !!this.headerText
+      return !!this.headerText;
     }
   }
 };


### PR DESCRIPTION
This PR modifies the `scaffold-alert` component to allow making the header optional. The header will now only be shown if text is passed into the `headerText` prop. In the case that the header is not visible, the speech button is now moved to the bottom row. If any of @heywooddogwood @johnarban @patudom have ideas on a better place to put it, feel free to modify.

Currently all of our guidelines do have values for `headerText`, but I'll modify e.g. https://github.com/cosmicds/hubbleds/pull/116 to make that not be the case.