### PR TITLE
Update guideline and MC components

### DIFF
--- a/cosmicds/components/mc_radiogroup.vue
+++ b/cosmicds/components/mc_radiogroup.vue
@@ -72,7 +72,14 @@ module.exports = {
     },
     radioOptions: Array,
     scoreTag: String,
-    selectedCallback: Function
+  },
+  emits: {
+    select(status) {
+      return typeof status.index === 'number' &&
+             typeof status.correct === 'boolean' &&
+             typeof status.neutral === 'boolean' &&
+             typeof status.tries === 'number';
+    }
   },
   created() {
     if (!this.scoreTag) { return; }
@@ -118,14 +125,12 @@ module.exports = {
           })
         );
       }
-      if (this.selectedCallback !== undefined) {
-        this.selectedCallback({
-          index: index,
-          correct: correct,
-          neutral: this.neutralAnswers.includes(index),
-          tries: this.tries
-        });
-      }
+      this.$emit('select', {
+        index: index,
+        correct: correct,
+        neutral: this.neutralAnswers.includes(index),
+        tries: this.tries
+      });
     },
     color: function(index) {
       if (this.correctAnswers.includes(index)) {

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -21,7 +21,7 @@
         <speech-synthesizer/>
       </v-col>
     </v-row>
-    <slot></slot>
+    <slot :advance="advance"></slot>
     <v-divider
       class="my-4"
     >


### PR DESCRIPTION
This PR updates the general guideline component to allow slot content to know whether or not the user is allowed to advance. The intended use case for this is to modify what content is shown based on whether the user has reached the point where they can advance.

This PR also updates the multiple choice component to emit a `select` event that a parent can respond to, rather than use a callback function prop. Ideally we shouldn't observe any change from this, but I think this will be a better design for this component going forward.