### PR TITLE
Prevent MC from reporting score too early

### DIFF
--- a/cosmicds/components/mc_radiogroup.vue
+++ b/cosmicds/components/mc_radiogroup.vue
@@ -104,8 +104,9 @@ module.exports = {
       this.column = index;
       this.tries += 1;
       const correct = this.correctAnswers.includes(index);
-      this.complete = correct;
-      this.score = this.scoring ? this.getScore(this.tries) : null;
+      const neutral = this.neutralAnswers.includes(index);
+      this.complete = correct || (this.correctAnswers.length === 0 && neutral);
+      this.score = (this.scoring && this.complete) ? this.getScore(this.tries) : null;
       if (this.scoreTag !== undefined && send) {
         document.dispatchEvent(
           new CustomEvent("mc-score", {


### PR DESCRIPTION
This PR is aimed at fixing the first issue noticed in https://github.com/cosmicds/hubbleds/pull/117#issuecomment-1374253410. This change updates the MC component to only report a non-null score value if a correct answer has been chosen (or a neutral answer, if there are no correct answers).