### PR TITLE
Color updates 2

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -89,7 +89,7 @@
               class="mr-3"
             >
               <v-avatar
-                color="info lighten-1"
+                color="warning"
               >
                 <v-icon dark>mdi-account-circle</v-icon>
               </v-avatar>
@@ -569,6 +569,18 @@ td:first-child, th:first-child {
 
 td.text-start {
   padding: 8px 16px!important;
+}
+
+.v-navigation-drawer .v-list-item--active.theme--light .v-list-item__content {
+  color: black;
+}
+
+.v-navigation-drawer .v-list-item--active.theme--dark .v-list-item__content {
+  color: white;
+}
+
+.v-window .v-toolbar {
+  border-bottom: solid 1px black!important;
 }
 
 .v-card__text {

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -50,6 +50,7 @@
         color="green"
         outlined
         class="mx-2"
+        style="background-color:#000A!important;"
       >
         <span
           class="white--text mr-2"

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -573,10 +573,12 @@ td.text-start {
 
 .v-navigation-drawer .v-list-item--active.theme--light .v-list-item__content {
   color: black;
+  z-index: 1;
 }
 
 .v-navigation-drawer .v-list-item--active.theme--dark .v-list-item__content {
   color: white;
+  z-index: 1;
 }
 
 .v-window .v-toolbar {

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -4,7 +4,7 @@
       app
       color="primary"
       dark
-      src="https://cdn.eso.org/images/screen/eso1738b.jpg"
+      src="https://www.astropix.org/archive/esahubble/opo22051a/esahubble_opo22051a_1600.jpg"
       clipped-right
       flat
       height="72"
@@ -13,7 +13,7 @@
       <template v-slot:img="{ props }">
         <v-img
           v-bind="props"
-          gradient="to top right, rgba(1, 87, 155, .7), rgba(0, 0, 0, .5)"
+          gradient="to top right, rgba(25, 71, 161, .2), rgba(8, 47, 104, .9)"
         ></v-img>
       </template>
 

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -26,10 +26,8 @@
       </v-row>
       <slot :advance="advance"></slot>
     </v-card-text>
-
-    <v-card-actions
-      style="background-color: #0004;"
-    >
+    <v-divider></v-divider>
+    <v-card-actions>
       <v-row
         align="center"
         class="pa-1"
@@ -37,8 +35,7 @@
       >
         <v-col
           v-if="!header"
-          cols="1"
-          class="mx-2"
+          class="mx-2 shrink"
         >
           <speech-synthesizer/>
         </v-col>
@@ -65,7 +62,7 @@
           class="shrink"
         >
           <div
-            style="font-size: 16px; border-left: solid 3px #FFD740; padding-left: 10px; color: #FFF8E1;"
+            style="font-size: 16px; border-left: solid 3px #FFD740; padding-left: 10px;"
           >
             <slot name="back-content"></slot>
           </div>
@@ -96,7 +93,7 @@
           class="shrink"
         >
           <div
-            style="font-size: 16px; border-left: solid 3px #FFD740; padding-left: 10px; color: #FFF8E1;"
+            style="font-size: 16px; border-left: solid 3px #FFD740; padding-left: 10px;"
           >
             <slot
               name="before-next"
@@ -111,11 +108,11 @@
 
 <style scoped>
 
-.theme--dark .v-card__text{
+.theme--dark .v-card__text, .theme--dark .v-card__actions{
   color: white!important;
 }
 
-.theme--light .v-card__text{
+.theme--light .v-card__text, .theme--light .v-card__actions{
   color: black!important;
 }
 

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -1,7 +1,7 @@
 <template>             
   <v-card
     color="info"
-    class="mb-4 mx-auto"
+    class="mb-4 mx-auto guideline"
     max-width="800"
     elevation="6"
   >
@@ -114,6 +114,10 @@
 
 .theme--light .v-card__text, .theme--light .v-card__actions{
   color: black!important;
+}
+
+.v-alert {
+  background-color: #000D!important;
 }
 
 </style>

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -1,11 +1,15 @@
 <template>
   <span>
     <slot>
-      <v-icon
-        @click="speak"
+      <v-btn
+        icon
       >
-        {{ speaking ? 'mdi-stop' : 'mdi-voice' }}
-      </v-icon>
+        <v-icon
+          @click="speak"
+        >
+          {{ speaking ? 'mdi-stop' : 'mdi-voice' }}
+        </v-icon>
+      </v-btn>
     </slot>
   </span>
 </template>


### PR DESCRIPTION
- set z-index for nav titles so that they stand out as white text.
- if mc-radiogroup is in a guideline, give it the answer/feedback v-alert a mostly black background.
-----
Navigation drawer updates:
- Avatar is now 'warning' red.
- Make text of navigation stages white/black.
- Add a black line to the bottom of headers (to help distinguish when dialogue content has scroll overflow.
-----
Change app bar src image (Still room to adjust, but the new image has less activity, so perhaps simplifies the design.)
-----
- darken the background of the piggy bank chip
- add divider to scaffolds
- turn speech-synthesizer into icon/button
- make text of v-card-actions white/black
- remove background from v-card-actions