### PR TITLE
Updates to layer toggler

### DIFF
--- a/cosmicds/components/table/table.py
+++ b/cosmicds/components/table/table.py
@@ -24,6 +24,7 @@ class Table(VuetifyTemplate, HubListener):
     search = Unicode().tag(sync=True)
     single_select = Bool(False).tag(sync=True)
     selected = List().tag(sync=True)
+    selected_class = Unicode("v-data-table__selected").tag(sync=True)
     sel_color = Unicode().tag(sync=True)
     sort_by = Unicode().tag(sync=True)
     title = Unicode().tag(sync=True)

--- a/cosmicds/components/table/table.vue
+++ b/cosmicds/components/table/table.vue
@@ -69,10 +69,6 @@
 
 export default {
 
-  data: {
-    selectedClass: "v-data-table__selected"
-  },
-
   methods: {
     updateStyling: function(selected, sortBy) {
       const sortFunc = function(x,y) {
@@ -92,9 +88,9 @@ export default {
       rows.shift(); // The first row will be the header
       for (const [index, row] of rows.entries()) {
         if (indices.includes(index)) {
-          row.classList.add(this.selectedClass);
+          row.classList.add(this.selected_class);
         } else {
-          row.classList.remove(this.selectedClass);
+          row.classList.remove(this.selected_class);
         }
       }
     },

--- a/cosmicds/tools/line_draw_tool.py
+++ b/cosmicds/tools/line_draw_tool.py
@@ -1,5 +1,6 @@
 from bqplot.marks import Lines, Scatter
 from bqplot_image_gl.interacts import MouseInteraction, mouse_events
+from echo import CallbackProperty
 from glue.config import viewer_tool
 from glue_jupyter.bqplot.common.tools import InteractCheckableTool
 from traitlets import Unicode, HasTraits
@@ -11,6 +12,7 @@ class LineDrawTool(InteractCheckableTool, HasTraits):
     action_text = 'Draw line'
     tool_tip = Unicode('Draw a trend line').tag(sync=True)
     mdi_icon = "mdi-message-draw"
+    line_drawn = CallbackProperty(False)
 
     def __init__(self, viewer, bx=0, by=0, **kwargs):
         super().__init__(viewer, **kwargs)
@@ -85,6 +87,7 @@ class LineDrawTool(InteractCheckableTool, HasTraits):
             endpoint.enable_move = True
             figure.marks = figure.marks + [endpoint]
             self.endpoint = endpoint
+            self.line_drawn = True
             self.tool_tip = "Update trend line"
 
             # End drawing
@@ -182,3 +185,4 @@ class LineDrawTool(InteractCheckableTool, HasTraits):
         figure.marks = [mark for mark in figure.marks if mark not in to_remove]
         self.line = None
         self.endpoint = None
+        self.line_drawn = False


### PR DESCRIPTION
This PR contains some updates to the layer toggler component. In particular, it modifies much of the internals to use layer states, for convenience when working with the viewer state's `layers` callback property.