### PR TITLE
Speech settings and improved speech behavior

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -15,7 +15,7 @@ from traitlets import Dict, Bool, Int
 
 from .events import WriteToDatabaseMessage
 from .registries import story_registry
-from .utils import CDSJSONEncoder, load_template
+from .utils import CDSJSONEncoder, debounce, load_template
 
 v.theme.dark = True
 
@@ -210,11 +210,14 @@ class Application(VuetifyTemplate, HubListener):
             "value": value
         })
 
+    @debounce(2)
     def _speech_rate_changed(self, rate):
         self._student_option_changed('speech_rate', rate)
 
+    @debounce(2)
     def _speech_pitch_changed(self, pitch):
         self._student_option_changed('speech_pitch', pitch)
 
+    @debounce(2)
     def _speech_autoread_changed(self, autoread):
         self._student_option_changed('speech_autoread', autoread)

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -31,6 +31,7 @@ class ApplicationState(State):
     speech_pitch = CallbackProperty(1)
     speech_rate = CallbackProperty(1)
     speech_autoread = CallbackProperty(False)
+    speech_voice = CallbackProperty(None)
 
 
 class Application(VuetifyTemplate, HubListener):
@@ -101,6 +102,7 @@ class Application(VuetifyTemplate, HubListener):
         add_callback(self.app_state, 'speech_rate', self._speech_rate_changed)
         add_callback(self.app_state, 'speech_pitch', self._speech_pitch_changed)
         add_callback(self.app_state, 'speech_autoread', self._speech_autoread_changed)
+        add_callback(self.app_state, 'speech_voice', self._speech_voice_changed)
 
     def reload(self):
         """
@@ -205,20 +207,23 @@ class Application(VuetifyTemplate, HubListener):
 
     def _student_option_changed(self, option, value):
         url = self.student_options_endpoint
-        response = requests.put(url, json={
+        requests.put(url, json={
             "option": option,
             "value": value
         })
-        print(response.text)
 
-    @debounce(2)
+    @debounce(1)
     def _speech_rate_changed(self, rate):
         self._student_option_changed('speech_rate', rate)
 
-    @debounce(2)
+    @debounce(1)
     def _speech_pitch_changed(self, pitch):
         self._student_option_changed('speech_pitch', pitch)
 
-    @debounce(2)
+    @debounce(1)
     def _speech_autoread_changed(self, autoread):
         self._student_option_changed('speech_autoread', autoread)
+
+    @debounce(1)
+    def _speech_voice_changed(self, voice):
+        self._student_option_changed('speech_voice', voice)

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -28,6 +28,9 @@ class ApplicationState(State):
     update_db = CallbackProperty(False)
     show_team_interface = CallbackProperty(True)
     allow_advancing = CallbackProperty(True)
+    speech_pitch = CallbackProperty(1)
+    speech_rate = CallbackProperty(1)
+    speech_autoread = CallbackProperty(False)
 
 
 class Application(VuetifyTemplate, HubListener):
@@ -35,14 +38,17 @@ class Application(VuetifyTemplate, HubListener):
     story_state = GlueState().tag(sync=True)
     template = load_template("app.vue", __file__, traitlet=True).tag(sync=True)
     drawer = Bool(True).tag(sync=True)
+    speech_menu = Bool(False).tag(sync=True)
     vue_components = Dict().tag(sync=True, **widget_serialization)
     app_state = GlueState().tag(sync=True)
+    speech_settings = GlueState().tag(sync=True)
     student_id = Int(0).tag(sync=True)
 
     def __init__(self, story, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.app_state = ApplicationState()
+        self.speech_state = ApplicationState()
 
         self.app_state.update_db = kwargs.get("update_db", True)
         self.app_state.show_team_interface = kwargs.get("show_team_interface",

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -155,9 +155,9 @@ class Application(VuetifyTemplate, HubListener):
         try:
             response = requests.get(self.student_options_endpoint)
             data = response.json()
-            print(data)
-            data.pop("student_id", 0)
-            self.app_state.update_from_dict(data)
+            if data is not None:
+                data.pop("student_id", 0)
+                self.app_state.update_from_dict(data)
         except ValueError as e:
             print(e)
 

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -41,14 +41,12 @@ class Application(VuetifyTemplate, HubListener):
     speech_menu = Bool(False).tag(sync=True)
     vue_components = Dict().tag(sync=True, **widget_serialization)
     app_state = GlueState().tag(sync=True)
-    speech_settings = GlueState().tag(sync=True)
     student_id = Int(0).tag(sync=True)
 
     def __init__(self, story, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.app_state = ApplicationState()
-        self.speech_state = ApplicationState()
 
         self.app_state.update_db = kwargs.get("update_db", True)
         self.app_state.show_team_interface = kwargs.get("show_team_interface",

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -32,6 +32,34 @@
         <template
           v-slot:activator="{ on, attrs }"
         >
+          <v-menu
+            v-model="speech_menu"
+            :close-on-content-click="false"
+            offset-y
+          >
+            <template v-slot:activator="{ props }">
+              <v-btn
+                icon
+                v-bind:value="[props, attrs]"
+                v-on="on"
+                @click="speech_menu = !speech_menu"
+              >
+                <v-icon>mdi-voice</v-icon>
+              </v-btn>
+            </template>
+            <speech-settings
+              :state="app_state"
+            />
+          </v-menu>
+        </template>
+        Adjust speech settings
+      </v-tooltip>
+      <v-tooltip
+        bottom
+      >
+        <template
+          v-slot:activator="{ on, attrs }"
+        >
           <v-btn
             icon
             v-bind="attrs"

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -21,7 +21,7 @@
         <v-col
           align="right"
         >
-          <speech-synthesizer :state="state"/>
+          <speech-synthesizer />
         </v-col>
       </v-row>
       <slot :advance="advance"></slot>

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -21,7 +21,7 @@
         <v-col
           align="right"
         >
-          <speech-synthesizer/>
+          <speech-synthesizer :state="state"/>
         </v-col>
       </v-row>
       <slot :advance="advance"></slot>

--- a/cosmicds/components/speech_settings.vue
+++ b/cosmicds/components/speech_settings.vue
@@ -66,7 +66,7 @@
         <v-select
           v-model="state.speech_voice"
           :items="window.speechSynthesis.getVoices()"
-          item-text="name"
+          :item-text="voice => `${voice.name} (${voice.lang})`"
           item-value="name"
           label="Select voice"
         ></v-select>

--- a/cosmicds/components/speech_settings.vue
+++ b/cosmicds/components/speech_settings.vue
@@ -1,0 +1,43 @@
+<template>
+  <v-card min-width="300">
+    <v-list>
+      <v-list-item>
+        <v-list-item-content>
+          <v-list-item-title>Speech Reader</v-list-item-title>
+          <v-list-item-subtitle>Adjust speech settings</v-list-item-subtitle>
+        </v-list-item-content>
+      </v-list-item>
+      <v-divider></v-divider>
+      <v-list-item>
+        <v-slider
+          v-model="state.speech_rate"
+          label="Rate"
+          color="blue"
+          :min="0.5"
+          :max="2"
+          :step="0.1"
+          thumb-label
+        >
+        </v-slider>
+      </v-list-item>
+      <v-list-item>
+        <v-slider
+          v-model="state.speech_pitch"
+          label="Pitch"
+          color="blue"
+          :min="0.1"
+          :max="2"
+          :step="0.1"
+          thumb-label
+        >
+        </v-slider>
+      </v-list-item>
+    </v-list>
+  </v-card>
+</template>
+
+<script>
+module.exports = {
+  props: ['state']
+}
+</script>

--- a/cosmicds/components/speech_settings.vue
+++ b/cosmicds/components/speech_settings.vue
@@ -22,7 +22,7 @@
           :min="0.5"
           :max="2"
           :step="0.1"
-          thumb-label
+          :thumb-label="false"
         >
         <template v-slot:prepend>
           <v-tooltip left>
@@ -46,7 +46,7 @@
           :min="0.1"
           :max="2"
           :step="0.1"
-          thumb-label
+          :thumb-label="false"
         >
         <template v-slot:prepend>
           <v-tooltip left>

--- a/cosmicds/components/speech_settings.vue
+++ b/cosmicds/components/speech_settings.vue
@@ -9,6 +9,12 @@
       </v-list-item>
       <v-divider></v-divider>
       <v-list-item>
+        <v-switch
+          v-model="state.speech_autoread"
+          label="Automatically read text"
+        ></v-switch>
+      </v-list-item>
+      <v-list-item>
         <v-slider
           v-model="state.speech_rate"
           label="Rate"

--- a/cosmicds/components/speech_settings.vue
+++ b/cosmicds/components/speech_settings.vue
@@ -17,26 +17,59 @@
       <v-list-item>
         <v-slider
           v-model="state.speech_rate"
-          label="Rate"
+          :label="state.speech_rate.toFixed(1)"
           color="blue"
           :min="0.5"
           :max="2"
           :step="0.1"
           thumb-label
         >
+        <template v-slot:prepend>
+          <v-tooltip left>
+            <template v-slot:activator="{ on }">
+              <v-icon
+                v-on="on"
+                @click="state.speech_rate = 1"
+              >
+                mdi-speedometer
+            </template>
+            Reset rate
+          </v-tooltip>
+        </template>
         </v-slider>
       </v-list-item>
       <v-list-item>
         <v-slider
           v-model="state.speech_pitch"
-          label="Pitch"
+          :label="state.speech_pitch.toFixed(1)"
           color="blue"
           :min="0.1"
           :max="2"
           :step="0.1"
           thumb-label
         >
+        <template v-slot:prepend>
+          <v-tooltip left>
+            <template v-slot:activator="{ on }">
+              <v-icon
+                v-on="on"
+                @click="state.speech_pitch = 1"
+              >
+                mdi-music-note
+            </template>
+            Reset pitch
+          </v-tooltip>
+        </template>
         </v-slider>
+      </v-list-item>
+      <v-list-item>
+        <v-select
+          v-model="state.speech_voice"
+          :items="window.speechSynthesis.getVoices()"
+          item-text="name"
+          item-value="name"
+          label="Select voice"
+        ></v-select>
       </v-list-item>
     </v-list>
   </v-card>

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -52,9 +52,9 @@ module.exports = {
         'cached': 'reset'
       },
       defaultVoicesURIs: [
-        "Microsoft Aria",
+        "Microsoft Aria Online (Natural) - English (United States)",
         "Google US English",
-        "Tessa"
+        "com.apple.speech.synthesis.voice.tessa"
       ],
       defaultVoice: null,
       utterances: new Set(),

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -78,8 +78,8 @@ module.exports = {
   methods: {
 
     triggerAutospeak() {
-      // const appComponent = this.$root.$children[0].$children[0];
-      const appComponent = document.querySelector("#inspire").__vue__;
+      const appComponent = this.$root.$children[0].$children[0];
+      // const appComponent = document.querySelector("#inspire").__vue__;
       if (appComponent.app_state.speech_autoread) {
         this.$nextTick(() => this.speak(true));
       }
@@ -161,8 +161,8 @@ module.exports = {
     },
     getSpeechOptions() {
       // TODO: Find a better way to access this piece of global state!
-      // const appComponent = this.$root.$children[0].$children[0];
-      const appComponent = document.querySelector("#inspire").__vue__;
+      const appComponent = this.$root.$children[0].$children[0];
+      // const appComponent = document.querySelector("#inspire").__vue__;
       const state = appComponent.app_state;
       const voiceName = state.speech_voice;
       const voice = window.speechSynthesis.getVoices().find(voice => voice.name == voiceName);

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -78,7 +78,8 @@ module.exports = {
   methods: {
 
     triggerAutospeak() {
-      const appComponent = this.$root.$children[0].$children[0];
+      // const appComponent = this.$root.$children[0].$children[0];
+      const appComponent = document.querySelector("#inspire").__vue__;
       if (appComponent.app_state.speech_autoread) {
         this.$nextTick(() => this.speak(true));
       }
@@ -160,8 +161,8 @@ module.exports = {
     },
     getSpeechOptions() {
       // TODO: Find a better way to access this piece of global state!
-      const appComponent = this.$root.$children[0].$children[0];
-      console.log(appComponent);
+      // const appComponent = this.$root.$children[0].$children[0];
+      const appComponent = document.querySelector("#inspire").__vue__;
       const state = appComponent.app_state;
       return {
         autoread: state.speech_autoread ?? false,

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -30,7 +30,6 @@ module.exports = {
       default: null
     }
   },
-  inject: ['appState'],
   data: function () {
     return {
       speaking: false,
@@ -42,8 +41,9 @@ module.exports = {
     };
   },
   mounted() {
-    console.log(this);
-    if (this.appState && this.appState.autoread) {
+    console.log(this.getSpeechOptions());
+    const appComponent = this.$root.$children[0].$children[0];
+    if (appComponent.app_state.speech_autoread) {
       this.speak();
     }
   },
@@ -54,6 +54,7 @@ module.exports = {
     }
   },
   methods: {
+
     elementText(element) {
 
       // Replace any MDI icons with text representing their name
@@ -124,10 +125,14 @@ module.exports = {
       }
     },
     getSpeechOptions() {
+      // TODO: Find a better way to access this piece of global state!
+      const appComponent = this.$root.$children[0].$children[0];
+      console.log(appComponent);
+      const state = appComponent.app_state;
       return {
-        autoread: this.appState.autoread ?? false,
-        pitch: this.appState.pitch ?? 1,
-        rate: this.appState.rate ?? 1
+        autoread: state.speech_autoread ?? false,
+        pitch: state.speech_pitch ?? 1,
+        rate: state.speech_rate ?? 1
       };
     },
     // Taken from https://www.geeksforgeeks.org/how-to-check-if-an-element-is-visible-in-dom/

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -164,11 +164,17 @@ module.exports = {
       // const appComponent = this.$root.$children[0].$children[0];
       const appComponent = document.querySelector("#inspire").__vue__;
       const state = appComponent.app_state;
-      return {
+      const voiceName = state.speech_voice;
+      const voice = window.speechSynthesis.getVoices().find(voice => voice.name == voiceName);
+      const options = {
         autoread: state.speech_autoread ?? false,
         pitch: state.speech_pitch ?? 1,
-        rate: state.speech_rate ?? 1
+        rate: state.speech_rate ?? 1,
       };
+      if (voice) {
+        options.voice = voice;
+      }
+      return options;
     },
     // Taken from https://www.geeksforgeeks.org/how-to-check-if-an-element-is-visible-in-dom/
     // TODO: Is there a better way to check?

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -46,7 +46,13 @@ module.exports = {
       rootElement: null,
       iconNameMap: {
         'cached': 'reset'
-      }
+      },
+      defaultVoicesURIs: [
+        "Microsoft Aria",
+        "Google US English",
+        "Tessa"
+      ],
+      defaultVoice: null
     };
   },
   mounted() {
@@ -165,7 +171,8 @@ module.exports = {
       // const appComponent = document.querySelector("#inspire").__vue__;
       const state = appComponent.app_state;
       const voiceName = state.speech_voice;
-      const voice = window.speechSynthesis.getVoices().find(voice => voice.name == voiceName);
+      this.defaultVoice = this.defaultVoice || window.speechSynthesis.getVoices().find(voice => this.defaultVoicesURIs.includes(voice.voiceURI));
+      const voice = window.speechSynthesis.getVoices().find(voice => voice.name == voiceName) || this.defaultVoice;
       const options = {
         autoread: state.speech_autoread ?? false,
         pitch: state.speech_pitch ?? 1,

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -74,23 +74,19 @@ module.exports = {
 
       entries.forEach((entry) => {
         console.log(entry.target);
-        console.log(this.rootElement);
         if (entry.target !== this.rootElement) { return; }
-        console.log(this);
-        console.log(`isSpeaking: ${this.isSpeaking()}`);
+        console.log(`speaking: ${this.speaking}`);
         console.log(`isIntersecting: ${entry.isIntersecting}`);
         console.log(`autoread: ${this.getSpeechOptions().autoread}`);
-        if (this.isSpeaking() && !entry.isIntersecting) {
-          this.stopSpeaking();
+        if (!entry.isIntersecting) {
+          this.stopThisSpeaking();
         } else if (!this.speaking && entry.isIntersecting && this.getSpeechOptions().autoread > 0) {
-          this.triggerAutospeak(false);
+          this.triggerAutospeak(true);
         }
       });
     };
     this.$nextTick(() => {
       this.findRootElement();
-      console.log("Here");
-      console.log(this.rootElement);
     });
   },
   destroyed() {
@@ -261,7 +257,7 @@ module.exports = {
 
     speak(forceSpeak=false, selectors=this.selectors) {
       const wasSpeaking = this.isSpeaking();
-      this.stopSpeaking();
+      this.cancelSpeech();
       console.log(`wasSpeaking: ${wasSpeaking}`);
       console.log(`forceSpeak: ${forceSpeak}`);
       if (wasSpeaking && !forceSpeak) {
@@ -290,18 +286,25 @@ module.exports = {
       });
     },
 
-    stopSpeaking() {
+    stopThisSpeaking() {
+      this.speaking = false;
       if (this.isSpeaking()) {
-        window.speechSynthesis.cancel();
-        clearInterval(this.intervalID);
-        this.speaking = false;
-        this.utterances.clear();
+        this.cancelSpeech();
       }
+    },
+
+    cancelSpeech() {
+      window.speechSynthesis.utterance = null;
+      window.speechSynthesis.cancel();
+      this.utterances.clear();
+      clearInterval(this.intervalID);
+      this.speaking = false;
     },
 
     // I made this a method rather than a computed since synth.speaking is not reactive
     isSpeaking() {
       const synth = window.speechSynthesis;
+      console.log(synth.utterance);
       return synth.speaking && this.utterances.has(synth.utterance);
     }
   },

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -29,6 +29,10 @@ module.exports = {
       type: [Object, Function],
       default: null
     },
+    elementFilter: {
+      type: [Function],
+      default: null
+    },
     autospeakOnChange: {
       type: [Boolean, Number],
       default: null
@@ -61,6 +65,7 @@ module.exports = {
     console.log("Mounting!");
     this.intersectionCallback = (entries, _observer) => {
       console.log("Inside intersection observer");
+      console.log(this);
       console.log(entries);
 
       // The IntersectionObserver is called once as soon as it's instantiated
@@ -240,7 +245,10 @@ module.exports = {
       console.log(this.rootElement);
       const selectedElements = this.rootElement.querySelectorAll(selectors.join(","));
       console.log(selectors);
-      const elements = [].concat(...selectedElements).filter(this.isElementVisible);
+      let elements = [].concat(...selectedElements).filter(this.isElementVisible);
+      if (this.elementFilter) {
+        elements = elements.filter(this.elementFilter);
+      }
       elements.forEach(el => {
         console.log(el);
         console.log(this.isElementVisible(el));

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -62,11 +62,7 @@ module.exports = {
     };
   },
   mounted() {
-    console.log("Mounting!");
     this.intersectionCallback = (entries, _observer) => {
-      console.log("Inside intersection observer");
-      console.log(this);
-      console.log(entries);
 
       // The IntersectionObserver is called once as soon as it's instantiated
       // We don't want that!
@@ -78,11 +74,7 @@ module.exports = {
       // }
 
       entries.forEach((entry) => {
-        console.log(entry.target);
         if (entry.target !== this.rootElement) { return; }
-        console.log(`speaking: ${this.speaking}`);
-        console.log(`isIntersecting: ${entry.isIntersecting}`);
-        console.log(`autoread: ${this.getSpeechOptions().autoread}`);
         if (!entry.isIntersecting) {
           this.stopThisSpeaking();
         } else if (!this.speaking && entry.isIntersecting && this.getSpeechOptions().autoread > 0) {
@@ -95,7 +87,6 @@ module.exports = {
     });
   },
   destroyed() {
-    console.log("Destroying!");
     if (this.stopOnClose && this.isSpeaking()) {
       clearInterval(this.intervalID);
       this.speaking = false;
@@ -120,7 +111,6 @@ module.exports = {
   methods: {
 
     triggerAutospeak(forceSpeak=true) {
-      console.log("In triggerAutospeak");
       const appComponent = this.$root.$children[0].$children[0];
       // const appComponent = document.querySelector("#inspire").__vue__;
       if (appComponent.app_state.speech_autoread) {
@@ -178,9 +168,7 @@ module.exports = {
       // Note that the pause-resume won't happen if the text takes longer than 14 seconds to say
       const synth = window.speechSynthesis;
       utterance.onstart = (_event) => {
-        console.log("Utterance onstart");
         this.intervalID = setInterval(() => {
-          console.log("Here");
           synth.pause();
           synth.resume();
         }, 14000);
@@ -188,7 +176,6 @@ module.exports = {
         this.speaking = true;
       }
       utterance.onend = (_event) => {
-        console.log("Utterance onend");
         synth.utterance = null;
         this.speaking = false;
         this.utterances.delete(utterance);
@@ -198,7 +185,6 @@ module.exports = {
       return utterance;
     },
     findRootElement() {
-      console.log("Inside findRootElement");
       if (this.root instanceof Element) {
         this.rootElement = this.root;
       } else if (this.root instanceof Function) {
@@ -242,20 +228,12 @@ module.exports = {
       if (this.rootElement === null) {
         this.findRootElement();
       }
-      console.log(this.rootElement);
       const selectedElements = this.rootElement.querySelectorAll(selectors.join(","));
-      console.log(selectors);
       let elements = [].concat(...selectedElements).filter(this.isElementVisible);
       if (this.elementFilter) {
         elements = elements.filter(this.elementFilter);
       }
-      elements.forEach(el => {
-        console.log(el);
-        console.log(this.isElementVisible(el));
-        console.log(this.elementText(el));
-      });
       const items = elements.map(element => this.elementText(element)).filter(text => text.length > 0);
-      console.log(items);
       return items;
     },
 
@@ -266,8 +244,6 @@ module.exports = {
     speak(forceSpeak=false, selectors=this.selectors) {
       const wasSpeaking = this.isSpeaking();
       this.cancelSpeech();
-      console.log(`wasSpeaking: ${wasSpeaking}`);
-      console.log(`forceSpeak: ${forceSpeak}`);
       if (wasSpeaking && !forceSpeak) {
         return;
       }
@@ -279,7 +255,6 @@ module.exports = {
       const options = this.getSpeechOptions();
       const utterances = items.map(item => this.makeUtterance(item, options));
       this.utterances = new Set(utterances);
-      console.log("Made utterances");
 
       // const lastUtterance = utterances[utterances.length - 1];
       // const lastOnEnd = lastUtterance.onend;
@@ -312,7 +287,6 @@ module.exports = {
     // I made this a method rather than a computed since synth.speaking is not reactive
     isSpeaking() {
       const synth = window.speechSynthesis;
-      console.log(synth.utterance);
       return synth.speaking && this.utterances.has(synth.utterance);
     }
   },
@@ -340,7 +314,6 @@ module.exports = {
       }
     },
     rootElement(newRoot, oldRoot) {
-      console.log("Changing root element");
       this.findingRoot = true;
       if (this.intersectionObserver) {
         this.intersectionObserver.unobserve(oldRoot);


### PR DESCRIPTION
This PR makes some updates to the speech synthesis functionality. In particular:
* There's a new speech settings widget that allows students to set various options for the speech reading, as well as whether or not they want the text to automatically be read. This widget can be opened using the new speech icon in the app bar. These options are persisted in a "student options" table in the backend database.

![speech_settings](https://user-images.githubusercontent.com/14281631/225705581-b574f9aa-03d7-4885-afb9-83bd0e8df7e9.png)

* Additionally, there have been some new props added to the speech synthesizer to allow speaking to be properly updated when closing or switching slides in one of the dialog slideshows.

I've marked this as a draft for now (and will do the same for the associated hubbleds PR). If there are any differences between desired behavior and what's implemented here, let me know and I'll change things accordingly.