### PR TITLE
Prevent line draw tool from getting stuck

### DIFF
--- a/cosmicds/tools/line_draw_tool.py
+++ b/cosmicds/tools/line_draw_tool.py
@@ -137,6 +137,12 @@ class LineDrawTool(InteractCheckableTool, HasTraits):
         self.viewer.figure.interaction = self._original_interaction
         self.viewer.toolbar.active_tool = None
 
+        # Make sure that we can't end up with the line defined but not the endpoint
+        if self.line is not None and self.endpoint is None:
+            fig = self.viewer.figure
+            fig.marks = [m for m in fig.marks if m != self.line]
+            self.line = None
+
     def close(self):
         super().close()
 

--- a/cosmicds/tools/line_draw_tool.py
+++ b/cosmicds/tools/line_draw_tool.py
@@ -10,12 +10,15 @@ class LineDrawTool(InteractCheckableTool, HasTraits):
 
     tool_id = 'cds:linedraw'
     action_text = 'Draw line'
-    tool_tip = Unicode('Draw a trend line').tag(sync=True)
+    draw_tool_tip = 'Draw a trend line'
+    update_tool_tip = 'Update trend line'
+    tool_tip = Unicode().tag(sync=True)
     mdi_icon = "mdi-message-draw"
     line_drawn = CallbackProperty(False)
 
     def __init__(self, viewer, bx=0, by=0, **kwargs):
         super().__init__(viewer, **kwargs)
+        self.tool_tip = self.draw_tool_tip
         self.line_drawn = False
         self.line = None
         self.endpoint = None
@@ -88,7 +91,7 @@ class LineDrawTool(InteractCheckableTool, HasTraits):
             figure.marks = figure.marks + [endpoint]
             self.endpoint = endpoint
             self.line_drawn = True
-            self.tool_tip = "Update trend line"
+            self.tool_tip = self.update_tool_tip
 
             # End drawing
             self.deactivate()
@@ -142,6 +145,7 @@ class LineDrawTool(InteractCheckableTool, HasTraits):
             fig = self.viewer.figure
             fig.marks = [m for m in fig.marks if m != self.line]
             self.line = None
+            self.tool_tip = self.draw_tool_tip
 
     def close(self):
         super().close()


### PR DESCRIPTION
This PR aims to resolve https://github.com/cosmicds/hubbleds/issues/135. The behavior here is changed so that if the line mark has been created but the endpoint hasn't when the tool is deactivated, the line is removed (basically, the tool is reset). @patudom Let me know if we want a different behavior here.

Note that this doesn't need to be merged in before any stage renaming - that won't have any effect on this repo.