### PR TITLE
Fix bug in layer toggler's `set_layer_order`

### DIFF
--- a/cosmicds/components/layer_toggle/layer_toggle.py
+++ b/cosmicds/components/layer_toggle/layer_toggle.py
@@ -43,7 +43,7 @@ class LayerToggle(VuetifyTemplate):
             return len(layers) + 1
 
     def set_layer_order(self, layers):
-        layers = [layer.state if isinstance(LayerArtist) else layer for layer in layers]
+        layers = [layer.state if isinstance(layer, LayerArtist) else layer for layer in layers]
         def sort_key(layer):
             if isinstance(layer, LayerArtist):
                 layer = layer.state

--- a/cosmicds/components/layer_toggle/layer_toggle.py
+++ b/cosmicds/components/layer_toggle/layer_toggle.py
@@ -43,6 +43,7 @@ class LayerToggle(VuetifyTemplate):
             return len(layers) + 1
 
     def set_layer_order(self, layers):
+        layers = [layer.state if isinstance(LayerArtist) else layer for layer in layers]
         def sort_key(layer):
             if isinstance(layer, LayerArtist):
                 layer = layer.state


### PR DESCRIPTION
This fixes a bug with the layer toggler's `set_layer_order` that @patudom and I noticed today.