### PR TITLE
Modify table population method to use `iterrows`

### DIFF
--- a/cosmicds/components/table/table.py
+++ b/cosmicds/components/table/table.py
@@ -165,8 +165,8 @@ class Table(VuetifyTemplate, HubListener):
         } for name, component in zip(self._glue_component_names, self._glue_components)]
         self.headers[0]['align'] = 'start'
         self.items = [
-            item for row in df.itertuples() if self.item_filter(item:={
-                component : self._transform(component)(getattr(row, component, None)) for component in self._glue_components
+            item for _, row in df.iterrows() if self.item_filter(item:={
+                component : self._transform(component)(row[component]) for component in self._glue_components
             })
         ]
 


### PR DESCRIPTION
This PR changes the table component to use `iterrows` rather than `itertuples`. The reason for this is because `itertuples` will rename the column names to positional identifiers if they aren't valid Python identifiers or start with an underscore (see [here](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.itertuples.html)). From testing this out, "positional identifiers" seems to mean "_<index>", but that isn't documented. While `itertuples` is quite a bit faster, I can't imagine us ever having enough data in a table and/or changing it frequently enough that it matters.