### PR TITLE
Allow toolbar to update tool's MDI icon and custom traits

### DIFF
--- a/cosmicds/components/toolbar/toolbar.py
+++ b/cosmicds/components/toolbar/toolbar.py
@@ -96,7 +96,9 @@ class Toolbar(VuetifyTemplate):
         self.update_tools_data(tool, data)
 
         if isinstance(tool, HasTraits):
-            for trait in self._TOOL_TRAITS:
-                if trait in tool.traits():
-                    tool.observe(self.refresh_tools_data, names=[trait])
+            names = [
+                trait for trait in tool.traits()
+                if trait in self._TOOL_TRAITS or tool.trait_metadata(trait, 'tools_data')
+            ]
+            tool.observe(self.refresh_tools_data, names=names)
 

--- a/cosmicds/components/toolbar/toolbar.py
+++ b/cosmicds/components/toolbar/toolbar.py
@@ -17,7 +17,7 @@ class Toolbar(VuetifyTemplate):
         'bqplot:rectangle': 'mdi-select-drag',
     }
 
-    _TOOL_TRAITS = ["tool_tip"]
+    _TOOL_TRAITS = ["tool_tip", "mdi_icon"]
 
     template = load_template("toolbar.vue", __file__, traitlet=True).tag(sync=True)
     active_tool = Instance(Tool, allow_none=True,


### PR DESCRIPTION
This PR allows the toolbar to automatically update the MDI icon of a tool, provided that the tool is an instance of `HasTraits` and that `mdi_icon` is defined as a `Unicode` traitlet. While only `tool_tip` and `mdi_icon` are default parts of the toolbar's `tools_data` traitlet, a tool can mark other traitlets with `.tag(tools_data=True)` to cause updates to those traitlets to refresh the toolbar's data in the template.