### PR TITLE
Add button refs to guideline component

### DIFF
--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -32,6 +32,7 @@
               class="black--text"
               color="accent"
               elevation="2"
+              ref="back"
               @click="() => { $emit('back'); }"
             >
               back
@@ -76,6 +77,7 @@
               class="black--text"
               color="accent"
               elevation="2"
+              ref="next"
               @click="() => { $emit('next'); }"
             >
               {{ nextText }}


### PR DESCRIPTION
This PR adds refs for the back and next buttons (the refs are called `back` and `next`, respectively) in the `scaffold-alert` guideline component. This makes it easier to access the back and next buttons as HTML elements from a containing component.