### PR TITLE
Improve behavior of tabbing for MathJax inputs

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -379,7 +379,8 @@ export default {
       options: {
         menuOptions: {
           settings: {
-            assistiveMml: true
+            assistiveMml: true,
+            inTabOrder: false
           }
         },
         a11y: {
@@ -705,6 +706,10 @@ mjx-container[jax="CHTML"][display="true"] {
 
 /** Hide bqplot legend 'checkmark' symbols */
 .g_legend path.line {
+  display: none;
+}
+
+mjx-assistive-mml cds-input {
   display: none;
 }
 </style>


### PR DESCRIPTION
This PR is intended to improve the behavior of tabbing with respect to input boxes in MathJax. Currently, our MathJax input boxes _are_ in the tab order, but the tab order around our MathJax blocks is rather bloated because the math itself, as well as `cds-input` elements inside the assisitive MML, are also in the tab order.

The approach here looks to handle both of these. First, set `inTabOrder: false` in the MathJax settings, which [removes math from the tabbing order](https://docs.mathjax.org/en/latest/options/menu.html?highlight=inTabOrder#the-configuration-block). Second, the `cds-input` elements in the assistive MML are set to be not visible. Note that they still exist in the DOM.