### PR TITLE
Functionality for setting bounds based on all visible layers

### DIFF
--- a/cosmicds/viewers/__init__.py
+++ b/cosmicds/viewers/__init__.py
@@ -1,1 +1,1 @@
-from .cds_viewer import CDSScatterState, CDSScatterView, CDSHistogramView
+from .cds_viewer import CDSScatterViewerState, CDSHistogramViewerState, CDSScatterView, CDSHistogramView

--- a/cosmicds/viewers/__init__.py
+++ b/cosmicds/viewers/__init__.py
@@ -1,1 +1,1 @@
-from .cds_viewers import cds_viewer, CDSHistogramView, CDSScatterView
+from .cds_viewer import CDSScatterState, CDSScatterView, CDSHistogramView

--- a/cosmicds/viewers/cds_viewer/__init__.py
+++ b/cosmicds/viewers/cds_viewer/__init__.py
@@ -1,0 +1,30 @@
+# This file is for viewers that don't need anything beyond
+# the standard CDS updating (the new toolbar, etc.)
+from glue_jupyter.bqplot.scatter import BqplotScatterView
+from glue_jupyter.bqplot.histogram import BqplotHistogramView
+
+from .state import CDSScatterState
+from .viewer import cds_viewer
+
+CDSScatterView = cds_viewer(
+    BqplotScatterView,
+    state_cls=CDSScatterState,
+    name='CDSScatterView',
+    viewer_tools=[
+        'bqplot:home',
+        'bqplot:rectzoom',
+        'bqplot:rectangle'
+    ],
+    label='2D scatter'
+)
+
+CDSHistogramView = cds_viewer(
+    BqplotHistogramView,
+    name='CDSHistogramView',
+    viewer_tools=[
+        'bqplot:home',
+        'bqplot:xzoom',
+        'bqplot:xrange'
+    ],
+    label='Histogram'
+)

--- a/cosmicds/viewers/cds_viewer/__init__.py
+++ b/cosmicds/viewers/cds_viewer/__init__.py
@@ -3,12 +3,12 @@
 from glue_jupyter.bqplot.scatter import BqplotScatterView
 from glue_jupyter.bqplot.histogram import BqplotHistogramView
 
-from .state import CDSScatterState
+from .state import CDSHistogramViewerState, CDSScatterViewerState
 from .viewer import cds_viewer
 
 CDSScatterView = cds_viewer(
     BqplotScatterView,
-    state_cls=CDSScatterState,
+    state_cls=CDSScatterViewerState,
     name='CDSScatterView',
     viewer_tools=[
         'bqplot:home',
@@ -20,6 +20,7 @@ CDSScatterView = cds_viewer(
 
 CDSHistogramView = cds_viewer(
     BqplotHistogramView,
+    state_cls=CDSHistogramViewerState,
     name='CDSHistogramView',
     viewer_tools=[
         'bqplot:home',

--- a/cosmicds/viewers/cds_viewer/state.py
+++ b/cosmicds/viewers/cds_viewer/state.py
@@ -1,16 +1,13 @@
-# This file is for viewers that don't need anything beyond
-# the standard CDS updating (the new toolbar, etc.)
-
 from math import ceil, floor
 
-from echo import add_callback, callback_property, CallbackProperty
-from glue.config import viewer_tool
-from glue_jupyter.bqplot.scatter import BqplotScatterView
-from glue_jupyter.bqplot.histogram import BqplotHistogramView
+from echo import add_callback, callback_property, delay_callback, CallbackProperty
+from glue.core import Subset
+from glue.viewers.histogram.state import HistogramViewerState
+from glue.viewers.scatter.state import ScatterViewerState
 from numpy import linspace, isnan
 
-from cosmicds.components.toolbar import Toolbar
 from cosmicds.utils import frexp10
+
 
 def cds_viewer_state(state_class):
 
@@ -124,85 +121,40 @@ def cds_viewer_state(state_class):
     return CDSViewerState
 
 
-def cds_viewer(viewer_class, name, viewer_tools=[], label=None, state_cls=None):
+class CDSScatterState(ScatterViewerState):
 
-    state_class = state_cls or viewer_class._state_cls
-    cds_state_class = cds_viewer_state(state_class)
+    def _layer_bounds(self, layer_state, att):
+        data = layer_state.layer
+        if isinstance(data, Subset):
+            subset = data
+            data = subset.data
+            subset_state = subset.subset_state
+        else:
+            subset_state = None
 
-    class CDSViewer(viewer_class):
-
-        __name__ = name
-        __qualname__ = name
-        _state_cls = cds_state_class
-        inherit_tools = viewer_tools is None
-        tools = viewer_tools or viewer_class.tools
-        LABEL = label or viewer_class.LABEL
-
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.ignore_conditions = []
-            add_callback(self.state, "xtick_values", self._update_xtick_values)
-            add_callback(self.state, "ytick_values", self._update_ytick_values)
-
-        def initialize_toolbar(self):
-
-            # If viewer_class has its own custom initialize_toolbar, defer to that
-            # This will ONLY be called if it's defined in viewer_class
-            if 'initialize_toolbar' in viewer_class.__dict__:
-                viewer_class.initialize_toolbar(self)
-                return
-            
-            self.toolbar = Toolbar(self)
-
-            for tool_id in self.tools:
-                mode_cls = viewer_tool.members[tool_id]
-                mode = mode_cls(self)
-                self.toolbar.add_tool(mode)
-
-        def ignore(self, condition):
-            self.ignore_conditions.append(condition)
-
-        def add_data(self, data):
-            if any(condition(data) for condition in self.ignore_conditions):
-                return False
-            return super().add_data(data)
-
-        def add_subset(self, subset):
-            if any(condition(subset) for condition in self.ignore_conditions):
-                return False
-            return super().add_subset(subset)
-
-        # The argument here can be either a Data or Subset object
-        def layer_artist_for_data(self, data):
-            return next((a for a in self.layers if a.layer == data), None)
-
-        def _update_xtick_values(self, values):
-            self.axis_x.tick_values = values
+        min_value = data.compute_statistic('minimum', att, subset_state=subset_state)
+        max_value = data.compute_statistic('maximum', att, subset_state=subset_state)
         
-        def _update_ytick_values(self, values):
-            self.axis_y.tick_values = values
+        rng = max_value - min_value
+        margin = 0.04  # Default glue scatter viewer value
+        min_value -= rng * margin
+        max_value += rng * margin
+        return min_value, max_value
+    
+    def _bounds_for_att(self, att):
+        bounds = [self._layer_bounds(layer, att) for layer in filter(lambda layer: layer.visible, self.layers)]
+        min_value = min((b[0] for b in bounds))
+        max_value = max((b[1] for b in bounds))
+        return min_value, max_value
+    
+    def _reset_x_limits(self):
+        x_min, x_max = self._bounds_for_att(self.x_att)
+        with delay_callback(self, 'x_min', 'x_max'):
+            self.x_min = x_min
+            self.x_max = x_max
 
-    return CDSViewer
-
-
-CDSScatterView = cds_viewer(
-    BqplotScatterView,
-    name='CDSScatterView',
-    viewer_tools=[
-        'cds:home',
-        'bqplot:rectzoom',
-        'bqplot:rectangle'
-    ],
-    label='2D scatter'
-)
-
-CDSHistogramView = cds_viewer(
-    BqplotHistogramView,
-    name='CDSHistogramView',
-    viewer_tools=[
-        'cds:home',
-        'bqplot:xzoom',
-        'bqplot:xrange'
-    ],
-    label='Histogram'
-)
+    def _reset_y_limits(self):
+        y_min, y_max = self._bounds_for_att(self.y_att)
+        with delay_callback(self, 'y_min', 'y_max'):
+            self.y_min = y_min
+            self.y_max = y_max

--- a/cosmicds/viewers/cds_viewer/viewer.py
+++ b/cosmicds/viewers/cds_viewer/viewer.py
@@ -1,0 +1,67 @@
+from echo import add_callback
+from glue.config import viewer_tool
+
+from cosmicds.components.toolbar import Toolbar
+
+from .state import cds_viewer_state
+
+
+def cds_viewer(viewer_class, name, viewer_tools=[], label=None, state_cls=None):
+
+    state_class = state_cls or viewer_class._state_cls
+    cds_state_class = cds_viewer_state(state_class)
+
+    class CDSViewer(viewer_class):
+
+        __name__ = name
+        __qualname__ = name
+        _state_cls = cds_state_class
+        inherit_tools = viewer_tools is None
+        tools = viewer_tools or viewer_class.tools
+        LABEL = label or viewer_class.LABEL
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.ignore_conditions = []
+            add_callback(self.state, "xtick_values", self._update_xtick_values)
+            add_callback(self.state, "ytick_values", self._update_ytick_values)
+
+        def initialize_toolbar(self):
+
+            # If viewer_class has its own custom initialize_toolbar, defer to that
+            # This will ONLY be called if it's defined in viewer_class
+            if 'initialize_toolbar' in viewer_class.__dict__:
+                viewer_class.initialize_toolbar(self)
+                return
+            
+            self.toolbar = Toolbar(self)
+
+            for tool_id in self.tools:
+                mode_cls = viewer_tool.members[tool_id]
+                mode = mode_cls(self)
+                self.toolbar.add_tool(mode)
+
+        def ignore(self, condition):
+            self.ignore_conditions.append(condition)
+
+        def add_data(self, data):
+            if any(condition(data) for condition in self.ignore_conditions):
+                return False
+            return super().add_data(data)
+
+        def add_subset(self, subset):
+            if any(condition(subset) for condition in self.ignore_conditions):
+                return False
+            return super().add_subset(subset)
+
+        # The argument here can be either a Data or Subset object
+        def layer_artist_for_data(self, data):
+            return next((a for a in self.layers if a.layer == data), None)
+
+        def _update_xtick_values(self, values):
+            self.axis_x.tick_values = values
+        
+        def _update_ytick_values(self, values):
+            self.axis_y.tick_values = values
+
+    return CDSViewer


### PR DESCRIPTION
This PR adds `CDSScatterViewerState` and `CDSHistogramViewerState` classes which implement custom limit-resetting behavior that uses the set of all visible layers to determine the min and max values. The `CDSScatterView` and `CDSHistogramView` types are updated to use these state classes, but we can also use/inherit from these classes in any of our other viewers. As part of these changes, I split the `cds_viewer` wrapper functionality into multiple files (one for state, one for the viewer itself).

Note that I didn't add any new triggers of `reset_limits` - for example, the limits won't change when a layer's visibility changes. To me, that feels like too much changing of the viewer to have as a default behavior, but I can add that or something similar if we want.