### PR TITLE
Require free responses to be filled out to advance

### DIFF
--- a/cosmicds/components/free_response.vue
+++ b/cosmicds/components/free_response.vue
@@ -44,8 +44,7 @@ module.exports = {
   data: function () {
     return {
       response: "",
-      initialized: false,
-      filledOut: false
+      initialized: false
     };
   },
 
@@ -81,11 +80,6 @@ module.exports = {
     onBlur(_event) {
       if (this.tag !== undefined) {
         this.dispatchUpdateEvent();
-
-        // Normally we would just have this be a computed
-        // but we want this to be in sync with the response
-        // that's been emitted, which only happens here
-        this.filledOut = this.response.length > 0;
       }
     },
 

--- a/cosmicds/components/free_response.vue
+++ b/cosmicds/components/free_response.vue
@@ -44,6 +44,7 @@ module.exports = {
     return {
       response: "",
       initialized: false,
+      filledOut: false
     };
   },
 
@@ -79,6 +80,11 @@ module.exports = {
     onBlur(_event) {
       if (this.tag !== undefined) {
         this.dispatchUpdateEvent();
+
+        // Normally we would just have this be a computed
+        // but we want this to be in sync with the response
+        // that's been emitted which only happens here
+        this.filledOut = response.length > 0;
       }
     },
 

--- a/cosmicds/components/free_response.vue
+++ b/cosmicds/components/free_response.vue
@@ -9,6 +9,7 @@
     :hint="hint"
     @blur="onBlur"
     v-intersect="dispatchInitializeEvent"
+    class="cds-free-response"
   >
     <template v-slot:label>
       <div>{{ label }}</div>
@@ -83,8 +84,8 @@ module.exports = {
 
         // Normally we would just have this be a computed
         // but we want this to be in sync with the response
-        // that's been emitted which only happens here
-        this.filledOut = response.length > 0;
+        // that's been emitted, which only happens here
+        this.filledOut = this.response.length > 0;
       }
     },
 

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -141,10 +141,10 @@ module.exports = {
           return;
         }
         if (mutation.addedNodes.length > 0) {
-          needUpdate = [...mutation.addedNodes].some(node => {
-            return node.classList != undefined &&
-            (node.classList.contains("cds-free-response") || node.querySelectorAll(".cds-free-response").length > 0);
-          });
+          needUpdate = [...mutation.addedNodes].some(this.needUpdateNode);
+        }
+        if (!needUpdate && mutation.removedNodes.length > 0) {
+          needUpdate = [...mutation.removedNodes].some(this.needUpdateNode);
         }
       });
       if (needUpdate) {
@@ -227,6 +227,15 @@ module.exports = {
 
     updateDisableNext() {
       this.disableNext = this.requireFr && !this.allFreeResponsesFilled();
+    },
+
+    needUpdateNode(node) {
+      return node.classList != undefined &&
+        (
+          node.classList.contains("cds-free-response")
+            ||
+          node.querySelectorAll(".cds-free-response").length > 0
+        );
     }
   }
 };

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -78,6 +78,7 @@
               color="accent"
               elevation="2"
               ref="next"
+              :disabled="disableNext"
               @click="() => { $emit('next'); }"
             >
               {{ nextText }}
@@ -127,6 +128,11 @@
 
 <script>
 module.exports = {
+  mounted() {
+    this.updateFreeResponseList();
+    this.updateDisableNext();
+    this.$el.addEventListener('change', (_event) => this.updateDisableNext());
+  },
   props: {
     allowBack: {
       type: Boolean,
@@ -143,8 +149,18 @@ module.exports = {
     canAdvance: {
       type: Function
     },
+    requireFr: {
+      type: Boolean,
+      default: true
+    },
     state: {
       type: Object
+    }
+  },
+  data() {
+    return {
+      freeResponses: [],
+      disableNext: false
     }
   },
   computed: {
@@ -157,6 +173,26 @@ module.exports = {
       } else {
         return this.headerText;
       }
+    }
+  },
+  methods: {
+
+    // These methods are kinda hacky!
+    // but they let us not ever have to deal with this stuff elsewhere
+    // and not have to rewrite this in each guideline that has free responses
+    updateFreeResponseList() {
+      const frElements = this.$el.querySelectorAll(".cds-free-response");
+      this.freeResponses = [...frElements].map(fr => fr.__vue__);
+    },
+
+    allFreeResponsesFilled() {
+      return this.freeResponses.every(fr => fr.filledOut);
+    },
+
+    updateDisableNext() {
+      setTimeout(() => {
+        this.disableNext = this.requireFr && !this.allFreeResponsesFilled();
+      }, 100);
     }
   }
 };

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -130,11 +130,7 @@
 module.exports = {
   mounted() {
     this.$nextTick(() => {
-      this.updateFreeResponseList(true);
       this.updateDisableNext();
-      this.$el.addEventListener('input', (_event) => {
-        this.updateDisableNext();
-      });
       this.initialized = true;
     });
   },
@@ -209,6 +205,11 @@ module.exports = {
       this.$nextTick(() => {
         if (!this.frsInitialized) {
           this.updateFreeResponseList();
+          if (this.freeResponses.length > 0) {
+            this.$el.addEventListener('input', (_event) => {
+              this.updateDisableNext();
+            });
+          }
         }
         this.disableNext = this.requireFr && !this.allFreeResponsesFilled();
       });


### PR DESCRIPTION
This PR adds functionality to the scaffold alert component so that free responses are required to be completed (currently defined as "the text field isn't empty"). This requirement is set to be true by default, but can be changed using the `require-fr` prop.

This is achieved by finding all of the free response components inside a guideline and, if there are any, checking whether each free response is complete whenever there's an input event. The nice thing about this approach is that we don't need to add anything to the actual guidelines themselves - everything is contained within the scaffold component.

Here's what this looks like in action:

https://user-images.githubusercontent.com/14281631/233387510-23a8fe53-4ffd-4c55-86c2-b38c44c4b8d3.mp4
