### PR TITLE
fix x range padding to work with no layers visible in dotplot

### DIFF
--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -125,13 +125,13 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
         else:
             self.state._y_min = 0
 
-        largest_y_max = max(getattr(layer, '_y_max', 0)
-                            for layer in self._viewer_state.layers if layer.visible)
+        largest_y_max = max((getattr(layer, '_y_max', 0)
+                            for layer in self._viewer_state.layers if layer.visible), default = self.state._y_max)
         if largest_y_max != self._viewer_state.y_max:
             self._viewer_state.y_max = largest_y_max
 
-        smallest_y_min = min(getattr(layer, '_y_min', inf)
-                             for layer in self._viewer_state.layers if layer.visible)
+        smallest_y_min = min((getattr(layer, '_y_min', inf)
+                             for layer in self._viewer_state.layers if layer.visible), default = self.state._y_min)
         if smallest_y_min != self._viewer_state.y_min:
             self._viewer_state.y_min = smallest_y_min
 

--- a/cosmicds/viewers/dotplot/state.py
+++ b/cosmicds/viewers/dotplot/state.py
@@ -1,4 +1,4 @@
-from echo.core import add_callback, delay_callback, CallbackProperty
+from echo.core import add_callback, delay_callback, CallbackProperty, ignore_callback
 from glue.viewers.histogram.state import HistogramLayerState, HistogramViewerState
 
 
@@ -23,6 +23,7 @@ class DotPlotViewerState(HistogramViewerState):
             largest_y_max = max(y_max, default=1)
             if largest_y_max != self.y_max:
                 self.y_max = largest_y_max
+        with ignore_callback(self, 'x_min', 'x_max'):
             padding = (self.x_max - self.x_min) * 0.05
             self.x_max = self.x_max + padding
             self.x_min = self.x_min - padding

--- a/cosmicds/viewers/dotplot/state.py
+++ b/cosmicds/viewers/dotplot/state.py
@@ -23,7 +23,6 @@ class DotPlotViewerState(HistogramViewerState):
             largest_y_max = max(y_max, default=1)
             if largest_y_max != self.y_max:
                 self.y_max = largest_y_max
-        with ignore_callback(self, 'x_min', 'x_max'):
             padding = (self.x_max - self.x_min) * 0.05
             self.x_max = self.x_max + padding
             self.x_min = self.x_min - padding

--- a/cosmicds/viewers/dotplot/state.py
+++ b/cosmicds/viewers/dotplot/state.py
@@ -1,4 +1,4 @@
-from echo.core import add_callback, delay_callback, CallbackProperty, ignore_callback
+from echo.core import add_callback, delay_callback, CallbackProperty
 from glue.viewers.histogram.state import HistogramLayerState, HistogramViewerState
 
 


### PR DESCRIPTION
 this isn't a "real" interaction, so we don't want associated callbacks to be called.

This fixes a small issue introduced in #212 where changing `x_max` or `x_min` fires a callback to update the y limits while no layers are visible. This is only a problem when hubble ds is at https://github.com/cosmicds/cosmicds/commit/64cce84a63bbfcda14de0ecddc66c11187cc0d76 (main as of Apr 21) because this version has no layers loaded when `viewer.state.reset_layers()` is called. Later version have at least one visible layer. 