### PR TITLE
Let viewers know their size

### DIFF
--- a/cosmicds/components/viewer_layout/viewer_layout.py
+++ b/cosmicds/components/viewer_layout/viewer_layout.py
@@ -1,6 +1,6 @@
 from ipyvuetify import VuetifyTemplate
 from ipywidgets import widget_serialization
-from traitlets import Bool, Dict, Instance, List, Unicode
+from traitlets import Bool, Dict, Instance, Int, List, Unicode, observe
 from ipywidgets import DOMWidget
 
 from ...utils import load_template
@@ -15,6 +15,8 @@ class ViewerLayout(VuetifyTemplate):
     show_toolbar = Bool(True).tag(sync=True)
     title = Unicode().tag(sync=True)
     classes = List().tag(sync=True)
+    viewer_width = Int().tag(sync=True)
+    viewer_height = Int().tag(sync=True)
 
     def __init__(self, viewer, classes=None, style=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -30,3 +32,12 @@ class ViewerLayout(VuetifyTemplate):
 
         self.css_style = style or {'height': '300px'}
         self.figure = viewer.figure_widget
+
+
+    @observe("viewer_width")
+    def _on_width_update(self, change):
+        self.viewer.state.viewer_width = change["new"]
+
+    @observe("viewer_height")
+    def _on_height_change(self, change):
+        self.viewer.state.viewer_height = change["new"]

--- a/cosmicds/components/viewer_layout/viewer_layout.vue
+++ b/cosmicds/components/viewer_layout/viewer_layout.vue
@@ -18,7 +18,7 @@
         <jupyter-widget :widget="controls.toolbar_selection_tools"></jupyter-widget>
       </v-toolbar-items>
     </v-toolbar>
-    <jupyter-widget class="viewer-widget" :style="css_style" :widget="figure"></jupyter-widget>
+    <jupyter-widget :style="css_style" :widget="figure"></jupyter-widget>
   </v-card>
 </template>
 
@@ -33,12 +33,13 @@ module.exports = {
     this.resizeObserver = new ResizeObserver((entries, _observer) => {
       entries.forEach((entry) => {
         const el = entry.target;
-        const viewerWidget = el.querySelector(".viewer-widget");
+        const viewerWidget = el.querySelector("rect.plotarea_events");
         if (!viewerWidget) {
           return;
         }
-        this.viewer_height = viewerWidget.clientHeight;
-        this.viewer_width = viewerWidget.clientWidth;
+        const bbox = viewerWidget.getBoundingClientRect();
+        this.viewer_height = Math.round(bbox.height);
+        this.viewer_width = Math.round(bbox.width); 
       });
     });
 

--- a/cosmicds/components/viewer_layout/viewer_layout.vue
+++ b/cosmicds/components/viewer_layout/viewer_layout.vue
@@ -18,6 +18,31 @@
         <jupyter-widget :widget="controls.toolbar_selection_tools"></jupyter-widget>
       </v-toolbar-items>
     </v-toolbar>
-    <jupyter-widget :style="css_style" :widget="figure"></jupyter-widget>
+    <jupyter-widget class="viewer-widget" :style="css_style" :widget="figure"></jupyter-widget>
   </v-card>
 </template>
+
+<script>
+module.exports = {
+  data() {
+    return {
+      resizeObserver: null
+    }
+  },
+  mounted() {
+    this.resizeObserver = new ResizeObserver((entries, _observer) => {
+      entries.forEach((entry) => {
+        const el = entry.target;
+        const viewerWidget = el.querySelector(".viewer-widget");
+        if (!viewerWidget) {
+          return;
+        }
+        this.viewer_height = viewerWidget.clientHeight;
+        this.viewer_width = viewerWidget.clientWidth;
+      });
+    });
+
+    this.resizeObserver.observe(this.$el);
+  }
+}
+</script>

--- a/cosmicds/components/viewer_layout/viewer_layout.vue
+++ b/cosmicds/components/viewer_layout/viewer_layout.vue
@@ -1,5 +1,6 @@
 <template>
   <v-card
+    v-intersect.once="(entries) => updateFromEntries(entries)"
     flat
     :class="classes"
   >
@@ -31,19 +32,28 @@ module.exports = {
   },
   mounted() {
     this.resizeObserver = new ResizeObserver((entries, _observer) => {
-      entries.forEach((entry) => {
-        const el = entry.target;
-        const viewerWidget = el.querySelector("rect.plotarea_events");
-        if (!viewerWidget) {
-          return;
-        }
-        const bbox = viewerWidget.getBoundingClientRect();
-        this.viewer_height = Math.round(bbox.height);
-        this.viewer_width = Math.round(bbox.width); 
-      });
+      this.updateFromEntries(entries);
     });
 
     this.resizeObserver.observe(this.$el);
+  },
+  methods: {
+    updateFromEntries(entries) {
+      entries.forEach((entry) => {
+        const el = entry.target;
+        this.updateViewerSizes(el);
+      });
+    },
+    updateViewerSizes(root=null) {
+      const el = root || this.$el;
+      const viewerWidget = el.querySelector("rect.plotarea_events");
+      if (!viewerWidget) {
+        return;
+      }
+      const bbox = viewerWidget.getBoundingClientRect();
+      this.viewer_height = Math.round(bbox.height);
+      this.viewer_width = Math.round(bbox.width);    
+    }
   }
 }
 </script>

--- a/cosmicds/viewers/cds_viewer/state.py
+++ b/cosmicds/viewers/cds_viewer/state.py
@@ -18,6 +18,9 @@ def cds_viewer_state(state_class):
         xtick_values = CallbackProperty([])
         ytick_values = CallbackProperty([])
 
+        viewer_height = CallbackProperty(400)
+        viewer_width = CallbackProperty(400)
+
         @staticmethod
         def tick_spacing(naive_spacing):
             mantissa, exp = frexp10(naive_spacing)

--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -50,6 +50,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
 
         add_callback(self._viewer_state, 'x_min', self._update_size)
         add_callback(self._viewer_state, 'x_max', self._update_size)
+        add_callback(self._viewer_state, 'hist_n_bin', self._update_size)
         add_callback(self._viewer_state, 'viewer_height', self._update_size)
         add_callback(self._viewer_state, 'viewer_width', self._update_size)
 
@@ -71,11 +72,10 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
             heights.append(y_pixel_height)
 
         pixel_height = min(heights, default=1)
-        axis = 'x' if pixel_height == heights[0] else 'y'
 
         # Shrink and scale height to add a bit of space
-        spacing = 1 
-        scaling = 0.75
+        spacing = 0.5
+        scaling = 0.86
         size = floor((pi / 4) * ((scaling * pixel_height - spacing) ** 2))
         size = max(size, 1)
         self.bars.default_size = size

--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -54,6 +54,8 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
         add_callback(self._viewer_state, 'viewer_height', self._update_size)
         add_callback(self._viewer_state, 'viewer_width', self._update_size)
 
+        self._update_size()
+
     def _update_size(self, arg=None):
         heights = []
         x_pixel_height = self._viewer_state.viewer_width / self._viewer_state.hist_n_bin

--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -51,8 +51,13 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
         add_callback(self._viewer_state, 'x_min', self._update_size)
         add_callback(self._viewer_state, 'x_max', self._update_size)
         add_callback(self._viewer_state, 'viewer_height', self._update_size)
+        add_callback(self._viewer_state, 'viewer_width', self._update_size)
 
     def _update_size(self, arg=None):
+        heights = []
+        x_pixel_height = (self._viewer_state.viewer_width + self.view.figure.fig_margin["right"]) / self._viewer_state.hist_n_bin
+        heights.append(x_pixel_height)
+
         if self._viewer_state.y_max is not None and self._viewer_state.y_min is not None:
             y_range = max(self._viewer_state.y_max - self._viewer_state.y_min, 1)
             if y_range == 0:
@@ -62,15 +67,18 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
             # The default_size parameter in bqplot specifies the area of the mark in pixels
             # but we know what pixel height (i.e. diameter) we want
             # so the size should be (pi / 4) * height ^ 2
-            pixel_height = (self._viewer_state.viewer_height + self.view.figure.fig_margin["top"]) / y_range
+            y_pixel_height = (self._viewer_state.viewer_height + self.view.figure.fig_margin["top"]) / y_range
+            heights.append(y_pixel_height)
 
+        pixel_height = min(heights, default=1)
+        axis = 'x' if pixel_height == heights[0] else 'y'
 
-            # Shrink and scale height to add a bit of space
-            spacing = 1
-            scaling = 0.7
-            size = floor((pi / 4) * ((scaling * pixel_height - spacing) ** 2))
-            size = max(size, 1)
-            self.bars.default_size = size
+        # Shrink and scale height to add a bit of space
+        spacing = 1
+        scaling = 0.7
+        size = floor((pi / 4) * ((scaling * pixel_height - spacing) ** 2))
+        size = max(size, 1)
+        self.bars.default_size = size
 
     def _scale_histogram(self):
         # TODO: comes from glue/viewers/histogram/layer_artist.py

--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -55,7 +55,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
 
     def _update_size(self, arg=None):
         heights = []
-        x_pixel_height = (self._viewer_state.viewer_width + self.view.figure.fig_margin["right"]) / self._viewer_state.hist_n_bin
+        x_pixel_height = self._viewer_state.viewer_width / self._viewer_state.hist_n_bin
         heights.append(x_pixel_height)
 
         if self._viewer_state.y_max is not None and self._viewer_state.y_min is not None:
@@ -67,15 +67,15 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
             # The default_size parameter in bqplot specifies the area of the mark in pixels
             # but we know what pixel height (i.e. diameter) we want
             # so the size should be (pi / 4) * height ^ 2
-            y_pixel_height = (self._viewer_state.viewer_height + self.view.figure.fig_margin["top"]) / y_range
+            y_pixel_height = self._viewer_state.viewer_height / y_range
             heights.append(y_pixel_height)
 
         pixel_height = min(heights, default=1)
         axis = 'x' if pixel_height == heights[0] else 'y'
 
         # Shrink and scale height to add a bit of space
-        spacing = 1
-        scaling = 0.7
+        spacing = 1 
+        scaling = 0.75
         size = floor((pi / 4) * ((scaling * pixel_height - spacing) ** 2))
         size = max(size, 1)
         self.bars.default_size = size

--- a/cosmicds/viewers/dotplot/state.py
+++ b/cosmicds/viewers/dotplot/state.py
@@ -1,10 +1,8 @@
 from echo.core import add_callback, delay_callback, CallbackProperty
-from glue.viewers.histogram.state import HistogramLayerState, HistogramViewerState
+from glue.viewers.histogram.state import HistogramLayerState
+from cosmicds.viewers.cds_viewer.state import CDSHistogramViewerState
 
-
-class DotPlotViewerState(HistogramViewerState):
-
-    viewer_height = CallbackProperty(400) # in pixels
+class DotPlotViewerState(CDSHistogramViewerState):
 
     def __init__(self, **kwargs):
         super(DotPlotViewerState, self).__init__(**kwargs)


### PR DESCRIPTION
This PR adds functionality that lets CosmicDS viewers be aware of their size on page. This is useful for things like the dotplot viewer (to which this PR applies this functionality, so this should help with https://github.com/cosmicds/hubbleds/issues/161), where the mark size depends on the figure size. The moving line functionality could also have used something like this - we were able to use pointer events to determine this information and it's not worth changing now, but this should help make similar things in the future easier.