### PR TITLE
Update scoring for neutral answers

### DIFF
--- a/cosmicds/components/mc_radiogroup.vue
+++ b/cosmicds/components/mc_radiogroup.vue
@@ -33,7 +33,7 @@
       >
       </div>
       <div
-        v-if="scoring && complete"
+        v-if="scoring && complete && score > 0"
         class="text-right"
       >
         <strong>{{ `+ ${score} ${score == 1 ? 'point' : 'points'}` }}</strong>
@@ -118,11 +118,15 @@ module.exports = {
   methods: {
     selectChoice: function(index, send=true) {
       this.column = index;
-      this.tries += 1;
       const correct = this.correctAnswers.includes(index);
       const neutral = this.neutralAnswers.includes(index);
+      if (!neutral) {
+        this.tries += 1;
+      }
       this.complete = correct || (this.correctAnswers.length === 0 && neutral);
-      this.score = (this.scoring && this.complete) ? this.getScore(this.tries) : null;
+      if (this.scoring && this.complete) {
+        this.score = correct ? this.getScore(this.tries) : 0;
+      }
       if (this.scoreTag !== undefined && send) {
         document.dispatchEvent(
           new CustomEvent("mc-score", {


### PR DESCRIPTION
This PR looks to resolve https://github.com/cosmicds/hubbleds/issues/173 by making the following changes:
* Not increase the number of tries if the student picks neutral answer (meaning they don't get penalized)
* Return a score of zero if the student advances with a neutral answer (i.e. when there isn't a correct answer)
* Not display the points text if the score is zero