### PR TITLE
Increase padding on dot plot viewer so the label on the measuring 

### DIFF
--- a/cosmicds/viewers/dotplot/state.py
+++ b/cosmicds/viewers/dotplot/state.py
@@ -21,7 +21,7 @@ class DotPlotViewerState(CDSHistogramViewerState):
             largest_y_max = max(y_max, default=1)
             if largest_y_max != self.y_max:
                 self.y_max = largest_y_max
-            padding = (self.x_max - self.x_min) * 0.05
+            padding = (self.x_max - self.x_min) * 0.15
             self.x_max = self.x_max + padding
             self.x_min = self.x_min - padding
 


### PR DESCRIPTION
tool can be read, else it sometimes falls off the edge of the viewer.
<img width="589" alt="Screen Shot 2023-04-29 at 8 14 32 PM" src="https://user-images.githubusercontent.com/12750048/235329280-c3b3dcfb-eb14-41c7-8948-2ab7fb7b7153.png">
