### PR TITLE
Improvements to speech settings

### DIFF
--- a/cosmicds/components/speech_settings.vue
+++ b/cosmicds/components/speech_settings.vue
@@ -77,6 +77,35 @@
 
 <script>
 module.exports = {
-  props: ['state']
+  props: ['state'],
+  created() {
+    window.speechSynthesis.onvoiceschanged = (_event) => {
+      this.updateVoiceList();
+    };
+    this.updateVoiceList();
+  },
+  data() {
+    return {
+      voiceURIs: [
+        'Google US English',
+        'urn:moz-tts:speechd:English%20(America)?en'
+        'Alex',
+        'Tessa',
+        'urn:moz-tts:osx:com.apple.speech.synthesis.voice.Alex',
+        'urn:moz-tts:osx:com.apple.speech.synthesis.voice.tessa',
+        'com.apple.speech.synthesis.voice.Alex',
+        'com.apple.speech.synthesis.voice.tessa',
+        'Microsoft Zira - English (United States)',
+        'Microsoft Aria Online (Natural) - English (United States)',
+        'urn:moz-tts:sapi:Microsoft Zira - English (United States)?en-US'
+      ],
+      voices: []
+    }
+  },
+  methods: {
+    updateVoiceList() {
+      this.voices = window.speechSynthesis.getVoices().filter(voice => this.voiceURIs.includes(voice.voiceURI));
+    }
+  }
 }
 </script>

--- a/cosmicds/components/speech_settings.vue
+++ b/cosmicds/components/speech_settings.vue
@@ -66,8 +66,8 @@
       </v-list-item>
       <v-list-item>
         <v-select
-          v-model="state.speech_voice"
-          :items="window.speechSynthesis.getVoices()"
+          v-model="voice"
+          :items="voices"
           :item-text="voice => `${voice.name} (${voice.lang})`"
           item-value="name"
           label="Select voice"
@@ -101,12 +101,18 @@ module.exports = {
         'Microsoft Aria Online (Natural) - English (United States)',
         'urn:moz-tts:sapi:Microsoft Zira - English (United States)?en-US'
       ],
-      voices: []
+      voices: [],
+      voice: null
     }
   },
   methods: {
     updateVoiceList() {
       this.voices = window.speechSynthesis.getVoices().filter(voice => this.voiceURIs.includes(voice.voiceURI));
+    }
+  },
+  watch: {
+    voice(newVoice) {
+      this.state.speech_voice = newVoice.voiceURI;
     }
   }
 }

--- a/cosmicds/components/speech_settings.vue
+++ b/cosmicds/components/speech_settings.vue
@@ -32,6 +32,7 @@
                 @click="state.speech_rate = 1"
               >
                 mdi-speedometer
+              </v-icon>
             </template>
             Reset rate
           </v-tooltip>
@@ -56,6 +57,7 @@
                 @click="state.speech_pitch = 1"
               >
                 mdi-music-note
+              </v-icon>
             </template>
             Reset pitch
           </v-tooltip>
@@ -88,7 +90,7 @@ module.exports = {
     return {
       voiceURIs: [
         'Google US English',
-        'urn:moz-tts:speechd:English%20(America)?en'
+        'urn:moz-tts:speechd:English%20(America)?en',
         'Alex',
         'Tessa',
         'urn:moz-tts:osx:com.apple.speech.synthesis.voice.Alex',

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -159,6 +159,7 @@ module.exports = {
       Object.keys(options).forEach(key => {
         utterance[key] = options[key];
       });
+      transformRate(utterance);
 
       // The interval is to work around this issue:
       // https://bugs.chromium.org/p/chromium/issues/detail?id=679437
@@ -288,8 +289,44 @@ module.exports = {
     isSpeaking() {
       const synth = window.speechSynthesis;
       return synth.speaking && this.utterances.has(synth.utterance);
-    }
-  },
+    },
+
+    function detectBrowser() {
+      let userAgent = navigator.userAgent;
+      let browserName;
+
+      if (userAgent.match(/chrome|chromium|crios/i)) {
+        browserName = "chrome";
+      } else if (userAgent.match(/firefox|fxios/i)) {
+        browserName = "firefox";
+      } else if (userAgent.match(/safari/i)) {
+        browserName = "safari";
+      } else if (userAgent.match(/opr\//i)) {
+        browserName = "opera";
+      } else if (userAgent.match(/edg/i)) {
+        browserName = "edge";
+      } else {
+        browserName = null;
+      }
+
+      return browserName
+    },
+
+    transformRate(utterance) {
+      const uri = utterance.voice.voiceURI;
+      if (uri === "Google US English") {
+        utterance.rate = Math.sqrt(2 * utterance.rate);
+      } else if (uri === 'Microsoft Zira - English (United States)') {
+        const browser = this.detectBrowser();
+        if (browser === 'chrome') {
+          utterance.rate = Math.pow(utterance.rate, 2.5);
+        } else if (browser === 'edge') {
+          utterance.rate = 1.5 * utterance.rate;
+        } else if (browser === 'firefox') {
+          utterance.rate = 1.2 * utterance.rate;
+        }
+      }
+    },
 
   watch: {
     // For the v-dialog slideshows, using nextTick (again, since triggerAutospeak uses it)

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -42,7 +42,7 @@ module.exports = {
       default: false
     }
   },
-  data: function () {
+  data() {
     return {
       utteranceSpeaking: false,
       speakingTimeoutID: null,
@@ -291,7 +291,7 @@ module.exports = {
       return synth.speaking && this.utterances.has(synth.utterance);
     },
 
-    function detectBrowser() {
+    detectBrowser() {
       let userAgent = navigator.userAgent;
       let browserName;
 
@@ -326,7 +326,9 @@ module.exports = {
           utterance.rate = 1.2 * utterance.rate;
         }
       }
-    },
+    }
+
+  },
 
   watch: {
     // For the v-dialog slideshows, using nextTick (again, since triggerAutospeak uses it)

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -54,7 +54,7 @@ module.exports = {
       defaultVoicesURIs: [
         "Microsoft Aria Online (Natural) - English (United States)",
         "Google US English",
-        "com.apple.speech.synthesis.voice.tessa"
+        "com.apple.speech.synthesis.voice.Alex"
       ],
       defaultVoice: null,
       utterances: new Set(),

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -159,7 +159,7 @@ module.exports = {
       Object.keys(options).forEach(key => {
         utterance[key] = options[key];
       });
-      transformRate(utterance);
+      this.transformRate(utterance);
 
       // The interval is to work around this issue:
       // https://bugs.chromium.org/p/chromium/issues/detail?id=679437
@@ -314,18 +314,19 @@ module.exports = {
 
     transformRate(utterance) {
       const uri = utterance.voice.voiceURI;
+      let rate = utterance.rate;
       if (uri === "Google US English") {
-        utterance.rate = Math.sqrt(2 * utterance.rate);
+        rate = Math.sqrt(2 * utterance.rate - 2 / 3) - 1 / 5;
       } else if (uri === 'Microsoft Zira - English (United States)') {
         const browser = this.detectBrowser();
         if (browser === 'chrome') {
-          utterance.rate = Math.pow(utterance.rate, 2.5);
+          rate = Math.pow(utterance.rate, 2.5);
         } else if (browser === 'edge') {
-          utterance.rate = 1.5 * utterance.rate;
-        } else if (browser === 'firefox') {
-          utterance.rate = 1.2 * utterance.rate;
+          rate = 1.5 * (utterance.rate - 0.25);
         }
       }
+      rate = Math.max(rate, 0.5);
+      utterance.rate = rate;
     }
 
   },

--- a/cosmicds/components/speech_synthesizer.vue
+++ b/cosmicds/components/speech_synthesizer.vue
@@ -313,6 +313,9 @@ module.exports = {
     },
 
     transformRate(utterance) {
+      if (!utterance.voice) {
+        return;
+      }
       const uri = utterance.voice.voiceURI;
       let rate = utterance.rate;
       if (uri === "Google US English") {


### PR DESCRIPTION
This PR makes the following changes to the app's speech settings:

* Only a finite set of voices are allowed to be selected. In general, this should allow 1-3 options for each student, depending on their browser and operating system. The allowed voices are those whose `voiceURI` value is included in the `voiceURIs` data value in the speech settings component.
* Some voice/browser combinations have rate adjustments based on the timing tests that I ran. The most significant of these is Google US English, both due to its behavior and because I expect it will be the most-used voice. In my testing, this voice seems to have a "true" speed rate which is a quadratic function of the rate assigned to the utterance; thus, we attempt to (roughly) undo that here.