### PR TITLE
Delay app loading until user info populated

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -56,9 +56,9 @@ class Application(VuetifyTemplate, HubListener):
 
         self.app_state.allow_advancing = kwargs.get("allow_advancing", False)
 
-        self.observe(lambda x: self.__setup(story, kwargs), 'user_info')
+        self.observe(lambda x: self._setup(story, **kwargs), 'user_info')
 
-    def __setup(self, story, kwargs):
+    def _setup(self, story, **kwargs):
         db_init = False
 
         create_new = kwargs.get("create_new_student", False)

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -295,7 +295,7 @@ export default {
     ).then(response=>response.json())
     .then(data=>{
         console.log(data);
-        vm.user_info = data;
+        vm.hub_user_info = data;
     });
   },
   async mounted() {

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -1,5 +1,14 @@
 <template>
   <v-app id="inspire">
+    <v-overlay :value="!hub_user_loaded"
+      opacity="0.75"
+      z-index=1000>
+      <v-progress-circular
+      indeterminate
+      color="primary"
+      ></v-progress-circular>
+      Loading User Data...
+    </v-overlay>
     <v-app-bar
       app
       color="primary"
@@ -289,7 +298,6 @@ export default {
         vm.user_info = data;
     });
   },
-
   async mounted() {
 
     // We ultimately don't want to expose this

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -270,6 +270,26 @@
 
 <script>
 export default {
+  created() {
+    // NOTE: THIS IS ONLY VALID FOR CONTAINDS USAGE
+    // The environment does not always reflect the actual user account that's
+    // using the app, so fetch the current user info
+    var vm = this;
+
+    fetch(
+        '/hub/dashboards-api/hub-info/user',
+        {
+            mode: 'no-cors',
+            credentials: 'same-origin',
+            headers: new Headers({'Access-Control-Allow-Origin':'*'})
+        }
+    ).then(response=>response.json())
+    .then(data=>{
+        console.log(data);
+        vm.user_info = data;
+    });
+  },
+
   async mounted() {
 
     // We ultimately don't want to expose this


### PR DESCRIPTION
This adds a delay to the application loading until the query to the hub information returns the actual user information.

This is only usable in the case of ContainDS with a primary dashboard instance.