### PR TITLE
Layout updates and instructions snackbar

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -43,6 +43,7 @@ class Application(VuetifyTemplate, HubListener):
     vue_components = Dict().tag(sync=True, **widget_serialization)
     app_state = GlueState().tag(sync=True)
     student_id = Int(0).tag(sync=True)
+    show_snackbar = Bool(True).tag(sync=True)
 
     def __init__(self, story, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -274,7 +274,7 @@
         top
         center
         color="info"
-        text="app_state.dark_mode ? 'white' : 'black!important'"
+        :text="app_state.dark_mode ? 'white' : 'black!important'"
         style="font-size: 1.2rem; line-height: 2"
         multi-line
         elevation="24"

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -731,4 +731,8 @@ mjx-assistive-mml cds-input {
   margin: 2px;
 }
 
+#inspire{
+  contain:layout
+}
+
 </style>

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -740,12 +740,12 @@ mjx-assistive-mml cds-input {
   contain:layout;
 }
 
-/*
-Don't think this is doing anything 
-  @media (min-width: 700px) {
-  .icon-img {
+/* This is not responding to window size, so just leave off for now.
+@media (min-width: 50px) {
+  */
+.icon-img {
     display: none;
   }
-} */
+
 
 </style>

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -44,7 +44,7 @@
                 v-on="on"
                 @click="speech_menu = !speech_menu"
               >
-                <v-icon>mdi-voice</v-icon>
+                <v-icon>mdi-tune</v-icon>
               </v-btn>
             </template>
             <speech-settings
@@ -267,6 +267,36 @@
           </div>
         </v-col>
       </v-row>
+      <v-snackbar
+        v-model="show_snackbar"
+        timeout="200000"
+        transition="fab-transition"
+        top
+        center
+        color="info"
+        text="app_state.dark_mode ? 'white' : 'black!important'"
+        style="font-size: 1.2rem; line-height: 2"
+        multi-line
+        elevation="24"
+      >
+        <p class="pt-3 pl-3">
+          <v-icon>mdi-tune</v-icon> &nbsp;adjust speech settings
+          <br>
+          <v-icon>mdi-brightness-4</v-icon> &nbsp;toggle light/dark mode
+          <br>
+          <v-icon>mdi-voice</v-icon> &nbsp;auto-read text
+
+        </p>
+        <v-btn
+          color="accent"
+          class="mx-4 black--text"
+          @click="{
+            show_snackbar=false;
+          }"
+        >
+          Close
+        </v-btn>
+      </v-snackbar>
     </v-footer>
   </v-app>
 </template>

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -7,7 +7,7 @@
       src="https://www.astropix.org/archive/esahubble/heic1518b/esahubble_heic1518b_1600.jpg"
       clipped-right
       flat
-      height="50"
+      height="60"
       style="z-index: 50;"
     >
       <template v-slot:img="{ props }">
@@ -108,9 +108,9 @@
       </v-responsive>
     </v-app-bar>
 
-    <v-navigation-drawer v-model="drawer" app width="200">
+    <v-navigation-drawer v-model="drawer" app width="250">
       <!-- TODO: This should be a built-in prop, but border radius requires explicit style def... -->
-      <v-sheet height="50" width="100%" style="border-radius: 0px">
+      <v-sheet height="60" width="100%" style="border-radius: 0px">
         <v-list class="ma-0 pa-0">
           <v-list-item>
             <v-list-item-action
@@ -118,8 +118,6 @@
             >
               <v-avatar
                 color="warning"
-                max-height="40"
-                max-width="40"
               >
                 <v-icon dark>mdi-account-circle</v-icon>
               </v-avatar>
@@ -127,7 +125,7 @@
 
             <v-list-item-content>
               <v-list-item-title>
-                Guest Student {{ student_id }}
+                Student {{ student_id }}
               </v-list-item-title>
             </v-list-item-content>
           </v-list-item>
@@ -636,7 +634,7 @@ td.text-start {
 }
 
 .v-alert {
-  font-size: 1rem !important;
+  font-size: 18px !important;
 }
 
 .v-navigation-drawer .v-list-item__action {

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -53,7 +53,7 @@
                 v-on="on"
                 @click="speech_menu = !speech_menu"
               >
-                <v-icon>mdi-tune</v-icon>
+                <v-icon>mdi-tune-vertical</v-icon>
               </v-btn>
             </template>
             <speech-settings
@@ -276,6 +276,7 @@
           </div>
         </v-col>
       </v-row>
+    </v-footer>
       <v-snackbar
         v-model="show_snackbar"
         timeout="200000"
@@ -283,13 +284,12 @@
         top
         center
         color="info"
-        :text="app_state.dark_mode ? 'white' : 'black!important'"
-        style="font-size: 1.2rem; line-height: 2"
+        :style="app_state.dark_mode ? 'font-size: 1em; line-height: 1.5; color:white' : 'font-size: 1em; line-height: 1.5; color:black !important'"
         multi-line
         elevation="24"
       >
         <p class="pt-3 pl-3">
-          <v-icon>mdi-tune</v-icon> &nbsp;adjust speech settings
+          <v-icon>mdi-tune-vertical</v-icon> &nbsp;adjust speech settings
           <br>
           <v-icon>mdi-brightness-4</v-icon> &nbsp;toggle light/dark mode
           <br>
@@ -306,7 +306,6 @@
           Close
         </v-btn>
       </v-snackbar>
-    </v-footer>
   </v-app>
 </template>
 

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -7,7 +7,7 @@
       src="https://www.astropix.org/archive/esahubble/heic1518b/esahubble_heic1518b_1600.jpg"
       clipped-right
       flat
-      height="72"
+      height="50"
       style="z-index: 50;"
     >
       <template v-slot:img="{ props }">
@@ -108,9 +108,9 @@
       </v-responsive>
     </v-app-bar>
 
-    <v-navigation-drawer v-model="drawer" app width="300">
+    <v-navigation-drawer v-model="drawer" app width="200">
       <!-- TODO: This should be a built-in prop, but border radius requires explicit style def... -->
-      <v-sheet height="72" width="100%" style="border-radius: 0px">
+      <v-sheet height="50" width="100%" style="border-radius: 0px">
         <v-list class="ma-0 pa-0">
           <v-list-item>
             <v-list-item-action
@@ -118,6 +118,8 @@
             >
               <v-avatar
                 color="warning"
+                max-height="40"
+                max-width="40"
               >
                 <v-icon dark>mdi-account-circle</v-icon>
               </v-avatar>
@@ -259,9 +261,12 @@
         </v-col>
         <v-col
           class="text-left"
+          style="align-self:center!important"
           cols="9"
         >
-          <span style="color:#BDBDBD!important; font-size:90%; line-height:80%; align-items:center">The material contained on this website is based upon work supported by NASA under award No. 80NSSC21M0002. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Aeronautics and Space Administration.</span>
+          <div style="color:#BDBDBD!important; font-size:70%; line-height:0.8em; align-self:center!important">
+            The material contained on this website is based upon work supported by NASA under award No. 80NSSC21M0002. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Aeronautics and Space Administration.
+          </div>
         </v-col>
       </v-row>
     </v-footer>
@@ -631,11 +636,11 @@ td.text-start {
 }
 
 .v-alert {
-  font-size: 18px !important;
+  font-size: 1rem !important;
 }
 
 .v-navigation-drawer .v-list-item__action {
-  margin: 12px 12px 12px 0px !important;
+  margin: 10px 10px 10px 0px !important;
 }
 
 label.v-label--active div {
@@ -726,13 +731,21 @@ mjx-assistive-mml cds-input {
 }
 
 .icon-img {
-  height: 40px !important;
+  height: 30px !important;
   vertical-align: middle;
   margin: 2px;
 }
 
 #inspire{
-  contain:layout
+  contain:layout;
 }
+
+/*
+Don't think this is doing anything 
+  @media (min-width: 700px) {
+  .icon-img {
+    display: none;
+  }
+} */
 
 </style>


### PR DESCRIPTION
- Add contain:layout to styling, which keeps the app all together in my notebook in Chrome (but doesn't work in every browser)
- Slightly reduce size of title bars, width of left menu, etc
- Remove logos in footer
- Add instructions snackbar that points out audio controls and light/dark toggle. 

Issues with snackbar:
- It probably doesn't need to appear after the first or second time a user has accessed the app and gets annoying in testing, but we can fix that later.
- I can't figure out how to get the snackbar text to be black in light mode. Ignoring for now.