### PR TITLE
Allow dotplotviewer to optionally use default histogram bars

### DIFF
--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -71,6 +71,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
             self.bars = Bars(**style, x = [0,1], y = [0,1])
         else:
             self.bars = Scatter(**style, x = [0,1], y = [0,1], marker = 'ellipse', default_skew = 0)
+            dlink((self.state, 'skew'), (self.bars, 'default_skew'))
         with delay_callback(self._viewer_state, 'y_min', 'y_max'):
             self._scale_histogram()
         self.view.figure.marks = marks + [self.bars]

--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -27,7 +27,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
             'rotation': LinearScale(min=0, max=180)
         }
         
-        if getattr(self.view,'use_bars',False):
+        if self.view.state.use_bars:
             self.bars = Bars(
                 scales=self.view.scales, x=[0, 1], y=[0, 1])
         else:
@@ -41,7 +41,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
 
         dlink((self.state, 'color'), (self.bars, 'colors'), lambda x: [color2hex(x)])
         dlink((self.state, 'alpha'), (self.bars, 'opacities'), lambda x: [x])
-        if  not getattr(self.view,'use_bars',False):
+        if  not self.view.state.use_bars:
             dlink((self.state, 'skew'), (self.bars, 'default_skew'))
 
         self._viewer_state.add_global_callback(self._update_histogram)
@@ -64,7 +64,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
         self._update_size()
 
     def _update_size(self, arg=None):
-        if getattr(self.view,'use_bars',False):
+        if self.view.state.use_bars:
             return
         heights = []
         x_pixel_height = self._viewer_state.viewer_width / self._viewer_state.hist_n_bin
@@ -92,7 +92,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
         self.bars.default_size = size
 
     def _scale_histogram(self):
-        if getattr(self.view,'use_bars',False):
+        if self.view.state.use_bars:
             super()._scale_histogram()
         
         # TODO: comes from glue/viewers/histogram/layer_artist.py

--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -27,20 +27,21 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
             'rotation': LinearScale(min=0, max=180)
         }
         
-        if getattr(self.view,'use_dots',True):
-            self.bars = Scatter(scales=self.scales,
-                                x=[0, 1],
-                                y=[0, 1],
-                                marker='ellipse')
-        else:
+        if getattr(self.view,'use_bars',False):
             self.bars = Bars(
                 scales=self.view.scales, x=[0, 1], y=[0, 1])
+        else:
+            self.bars = Scatter(scales=self.scales,
+                            x=[0, 1],
+                            y=[0, 1],
+                            marker='ellipse')
+            
 
         self.view.figure.marks = list(self.view.figure.marks) + [self.bars]
 
         dlink((self.state, 'color'), (self.bars, 'colors'), lambda x: [color2hex(x)])
         dlink((self.state, 'alpha'), (self.bars, 'opacities'), lambda x: [x])
-        if  getattr(self.view,'use_dots',True):
+        if  not getattr(self.view,'use_bars',False):
             dlink((self.state, 'skew'), (self.bars, 'default_skew'))
 
         self._viewer_state.add_global_callback(self._update_histogram)
@@ -63,7 +64,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
         self._update_size()
 
     def _update_size(self, arg=None):
-        if not getattr(self.view,'use_dots',True):
+        if getattr(self.view,'use_bars',False):
             return
         heights = []
         x_pixel_height = self._viewer_state.viewer_width / self._viewer_state.hist_n_bin
@@ -91,7 +92,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
         self.bars.default_size = size
 
     def _scale_histogram(self):
-        if not getattr(self.view,'use_dots',True):
+        if getattr(self.view,'use_bars',False):
             super()._scale_histogram()
         
         # TODO: comes from glue/viewers/histogram/layer_artist.py
@@ -123,7 +124,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
             x.extend([x_i] * counts[i])
             y.extend(y_i)
         
-        if getattr(self.view,'use_dots',True):
+        if not getattr(self.view,'use_bars',False):
             self.bars.x = x
             self.bars.y = y
             self._update_size()

--- a/cosmicds/viewers/dotplot/layer_artist.py
+++ b/cosmicds/viewers/dotplot/layer_artist.py
@@ -93,7 +93,7 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
     def _scale_histogram(self):
         if not getattr(self.view,'use_dots',True):
             super()._scale_histogram()
-            return
+        
         # TODO: comes from glue/viewers/histogram/layer_artist.py
         if self.bins is None:
             return  # can happen when the subset is empty
@@ -122,10 +122,11 @@ class BqplotDotPlotLayerArtist(BqplotHistogramLayerArtist):
             y_i = range(1, counts[i] + 1)
             x.extend([x_i] * counts[i])
             y.extend(y_i)
-     
-        self.bars.x = x
-        self.bars.y = y if getattr(self.view,'use_dots',True) else counts
-        self._update_size()
+        
+        if getattr(self.view,'use_dots',True):
+            self.bars.x = x
+            self.bars.y = y
+            self._update_size()
 
         # We have to do the following to make sure that we reset the y_max as
         # needed. We can't simply reset based on the maximum for this layer

--- a/cosmicds/viewers/dotplot/state.py
+++ b/cosmicds/viewers/dotplot/state.py
@@ -3,6 +3,8 @@ from glue.viewers.histogram.state import HistogramLayerState
 from cosmicds.viewers.cds_viewer.state import CDSHistogramViewerState
 
 class DotPlotViewerState(CDSHistogramViewerState):
+    
+    use_bars = CallbackProperty(False)
 
     def __init__(self, **kwargs):
         super(DotPlotViewerState, self).__init__(**kwargs)

--- a/cosmicds/viewers/dotplot/state.py
+++ b/cosmicds/viewers/dotplot/state.py
@@ -5,6 +5,9 @@ from cosmicds.viewers.cds_viewer.state import CDSHistogramViewerState
 class DotPlotViewerState(CDSHistogramViewerState):
     
     use_bars = CallbackProperty(False)
+    
+    viewer_height = CallbackProperty(400)
+    viewer_width = CallbackProperty(400)
 
     def __init__(self, **kwargs):
         super(DotPlotViewerState, self).__init__(**kwargs)

--- a/cosmicds/viewers/dotplot/viewer.py
+++ b/cosmicds/viewers/dotplot/viewer.py
@@ -13,10 +13,9 @@ class BqplotDotPlotView(BqplotHistogramView):
 
     tools = BqplotHistogramView.tools + ["bqplot:xzoom"]
 
-    def __init__(self, session, state=None, use_bars = False):
+    def __init__(self, session, state=None):
         super(BqplotDotPlotView, self).__init__(session, state=state)
         self.figure.layout.observe(self._update_height, names='height')
-        self.use_bars = use_bars
 
     def _update_height(self, change):
         # For now, we just assume that the height is entered in pixels

--- a/cosmicds/viewers/dotplot/viewer.py
+++ b/cosmicds/viewers/dotplot/viewer.py
@@ -13,9 +13,10 @@ class BqplotDotPlotView(BqplotHistogramView):
 
     tools = BqplotHistogramView.tools + ["bqplot:xzoom"]
 
-    def __init__(self, session, state=None):
+    def __init__(self, session, state=None, use_dots = True):
         super(BqplotDotPlotView, self).__init__(session, state=state)
         self.figure.layout.observe(self._update_height, names='height')
+        self.use_dots = use_dots
 
     def _update_height(self, change):
         # For now, we just assume that the height is entered in pixels

--- a/cosmicds/viewers/dotplot/viewer.py
+++ b/cosmicds/viewers/dotplot/viewer.py
@@ -13,10 +13,10 @@ class BqplotDotPlotView(BqplotHistogramView):
 
     tools = BqplotHistogramView.tools + ["bqplot:xzoom"]
 
-    def __init__(self, session, state=None, use_dots = True):
+    def __init__(self, session, state=None, use_bars = False):
         super(BqplotDotPlotView, self).__init__(session, state=state)
         self.figure.layout.observe(self._update_height, names='height')
-        self.use_dots = use_dots
+        self.use_bars = use_bars
 
     def _update_height(self, change):
         # For now, we just assume that the height is entered in pixels


### PR DESCRIPTION
This is a small enhancement to make the dotplot viewer a bit more broadly useful. Basically giving a histogram with the unique features of the dotplot (rescaling bins and height). It is set up to that it doesn't change the current workflow. 

Normal operation: `HubbleDotPlotView()`
<img width="767" alt="image" src="https://github.com/cosmicds/cosmicds/assets/7862929/692b345f-fedf-4993-9fc7-b3c66435b568">

With ~`HubbleDotPlotView(use_bars = True)`~ `viewer.state.use_bars = True`
<img width="743" alt="image" src="https://github.com/cosmicds/cosmicds/assets/7862929/083dd81b-b8c6-446f-8464-0a31b37a9e78">
