### PR TITLE
Highlight current stage in navigation drawer

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -157,6 +157,7 @@
             :complete="story_state.max_stage_index > index"
             :step="index"
             :edit-icon="'$complete'"
+            :class="{ info: story_state.stage_index === index }"
           >
             {{ stage.title }}
           </v-stepper-step>


### PR DESCRIPTION
This PR looks to resolve https://github.com/cosmicds/hubbleds/issues/247 by highlighting the current stage in the navigation drawer with the info color.