### PR TITLE
Only show initial snackbar once user info has loaded

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -44,7 +44,7 @@ class Application(VuetifyTemplate, HubListener):
     vue_components = Dict().tag(sync=True, **widget_serialization)
     app_state = GlueState().tag(sync=True)
     student_id = Int(0).tag(sync=True)
-    show_snackbar = Bool(True).tag(sync=True)
+    show_snackbar = Bool(False).tag(sync=True)
     hub_user_info = Dict().tag(sync=True)
     hub_user_loaded = Bool(False).tag(sync=True)
 
@@ -119,6 +119,7 @@ class Application(VuetifyTemplate, HubListener):
         add_callback(self.app_state, 'speech_voice', self._speech_voice_changed)
 
         self.hub_user_loaded = True
+        self.show_snackbar = True
 
     def reload(self):
         """

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -289,11 +289,11 @@
         elevation="24"
       >
         <p class="pt-3 pl-3">
-          <v-icon>mdi-tune-vertical</v-icon> &nbsp;adjust speech settings
+          <v-icon>mdi-tune-vertical</v-icon> &nbsp;Adjust speech settings
           <br>
-          <v-icon>mdi-brightness-4</v-icon> &nbsp;toggle light/dark mode
+          <v-icon>mdi-brightness-4</v-icon> &nbsp;Toggle light/dark mode
           <br>
-          <v-icon>mdi-voice</v-icon> &nbsp;auto-read text
+          <v-icon>mdi-voice</v-icon> &nbsp;Auto-read text
 
         </p>
         <v-btn


### PR DESCRIPTION
This PR resolves https://github.com/cosmicds/hubbleds/issues/255 by not showing the snackbar until the user info has loaded. In particular, this means that the snackbar shouldn't show on the deployed app until the user info has loaded.

@patudom Is it okay if I deploy this branch on the server to test it out? This _should_ work, but it's hard to be sure without trying it live.