### PR TITLE
Add percentage and statistic selectors

### DIFF
--- a/cosmicds/components/__init__.py
+++ b/cosmicds/components/__init__.py
@@ -1,4 +1,6 @@
 from .generic_state_component import *
+from .percentage_selector import *
+from .statistics_selector import *
 from .table import *
 from .toolbar import *
 from .viewer_layout import *

--- a/cosmicds/components/layer_toggle/layer_toggle.vue
+++ b/cosmicds/components/layer_toggle/layer_toggle.vue
@@ -39,8 +39,8 @@
 
 <style scoped>
 
-.v-card{
-  border: solid 1px black!important;
+.v-card {
+  border: solid 1px black !important;
 }
 
 </style>

--- a/cosmicds/components/percentage_selector/__init__.py
+++ b/cosmicds/components/percentage_selector/__init__.py
@@ -1,0 +1,1 @@
+from .percentage_selector import PercentageSelector

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -2,7 +2,6 @@ from ipyvuetify import VuetifyTemplate
 from numpy import array, percentile
 from traitlets import Float, Int, List, Unicode, observe
 
-from glue.core import Data
 from glue.core.subset import RangeSubsetState
 
 from ...utils import load_template
@@ -10,11 +9,9 @@ from ...utils import load_template
 class PercentageSelector(VuetifyTemplate):
     
     template = load_template("percentage_selector.vue", __file__, traitlet=True).tag(sync=True)
-    color = Unicode("#1e90ff").tag(sync=True)
+    radio_color = Unicode("#1e90ff").tag(sync=True)
     options = List([50, 68, 95]).tag(sync=True)
-    selected = Int(allow_none=True).tag(sync=True)
-    selected_min = Float().tag(sync=True)
-    selected_max = Float().tag(sync=True)
+    selected = Int(None, allow_none=True).tag(sync=True)
     unit = Unicode().tag(sync=True)
     was_selected = Int(allow_none=True).tag(sync=True)
 
@@ -24,73 +21,89 @@ class PercentageSelector(VuetifyTemplate):
     # to deal with cases where, for either setup or story reasons,
     # the layer doesn't exist in the viewer when we have to create
     # this component (which will be in the stage initializer)
-    def __init__(self, viewer, data, *args, **kwargs):
+    def __init__(self, viewers, data, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.viewer = viewer
+        self.viewers = viewers
         self.glue_data = data
         self._bins = kwargs.get("bins", None)
+        self._original_colors = []
         if "options" in kwargs:
             self.options = kwargs["options"]
-        self.subset_label = kwargs.get("subset_label", None)
+        self.subset_labels = kwargs.get("subset_labels", [])
         self.subset_group = kwargs.get("subset_group", False)
         self.lower_transform = kwargs.get("lower_transform", None)
         self.upper_transform = kwargs.get("upper_transform", None)
-        self.subset = None
-        if "unit" in kwargs:
-            self.unit = kwargs["unit"]
+        self.subsets = []
+        if "units" in kwargs:
+            self.units = kwargs["units"]
 
     @property
     def bins(self):
         if self._bins is not None:
             return self._bins
-        if hasattr(self.viewer.state, "bins"):
-            return self.viewer.state.bins
-        return None
+        return [getattr(viewer.state, "bins", None) for viewer in self.viewers]
 
-    def _update_subset(self, state):
-        if self.subset is None:
-            kwargs = { "color": self.color, "alpha": 1 }
-            if self.subset_label:
-                kwargs["label"] = self.subset_label
-            if self.subset_group:
-                self.subset = self.viewer.session.data_collection.new_subset_group(state, **kwargs)
-            else:
-                self.subset = self.glue_data.new_subset(state, **kwargs)
-                self.viewer.add_subset(self.subset)
+    def _update_subsets(self, states):
+        if not self.subsets:
+            kwargs = { "alpha": 1 }
+            session = self.viewers[0].session
+            for index in range(len(self.viewers)):
+                data = self.glue_data[index]
+                state = states[index]
+                if self.subset_labels:
+                    kwargs["label"] = self.subset_labels[index]
+                kwargs["color"] = self._original_colors[index]
+                if self.subset_group:
+                    subset = session.data_collection.new_subset_group(state, **kwargs)
+                else:
+                    subset = data.new_subset(state, **kwargs)
+                    self.viewers[index].add_subset(subset)
+                self.subsets.append(subset)
         else:
-            self.subset.subset_state = state
+            for (subset, state) in zip(self.subsets, states):
+                subset.subset_state = state
 
     @property
-    def layer(self):
-        return self.viewer.layer_artist_for_data(self.glue_data)
+    def layers(self):
+        return [viewer.layer_artist_for_data(data) for (data, viewer) in zip(self.glue_data, self.viewers)]
 
     @observe('selected')
     def _update(self, change):
-        if self.layer is None:
-            return
+        if change["old"] is None:
+            self._original_colors = [layer.state.color for layer in self.layers]
+
         selected = change["new"]
         if selected is None:
-            state = array([False for _ in range(self.glue_data.size)])
-            self.layer.state.color = self.color
-            self._update_subset(state)
+            states = []
+            for index in range(len(self.viewers)):
+                if self.layers[index] is not None:
+                    self.layers[index].state.color = self._original_colors[index]
+                state = array([False for _ in range(self.glue_data[index].size)])
+                states.append(state)
+            self._update_subsets(states)
             return
 
-        self.layer.state.color = self._deselected_color
         around_median = selected / 2
         bottom_percent = 50 - around_median
         top_percent = 50 + around_median
-        component_id = self.viewer.state.x_att
-        data = self.glue_data[component_id]
-        bottom = percentile(data, bottom_percent, method="nearest")
-        top = percentile(data, top_percent, method="nearest")
-        state = RangeSubsetState(bottom, top, component_id)
-        if self.bins is not None:
-            bottom = next((x for x in self.bins if x > bottom), bottom)
-            top = next((x for x in self.bins if x > top), top)
-        if self.lower_transform is not None:
-            bottom = self.lower_transform(bottom)
-        if self.upper_transform is not None:
-            top = self.upper_transform(top)
-        self.selected_min = bottom
-        self.selected_max = top
-        self._update_subset(state)
+
+        states = []
+        for (index, viewer) in enumerate(self.viewers):
+            component_id = viewer.state.x_att
+            data = self.glue_data[index][component_id]
+            self.layers[index].state.color = self._deselected_color
+            bottom = percentile(data, bottom_percent, method="nearest")
+            top = percentile(data, top_percent, method="nearest")
+            state = RangeSubsetState(bottom, top, component_id)
+            states.append(state)
+            bins = self.bins[index]
+            if bins is not None:
+                bottom = next((x for x in bins if x > bottom), bottom)
+                top = next((x for x in bins if x > top), top)
+            if self.lower_transform is not None:
+                bottom = self.lower_transform(bottom)
+            if self.upper_transform is not None:
+                top = self.upper_transform(top)
+
+        self._update_subsets(states)
+

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -1,17 +1,23 @@
 from ipyvuetify import VuetifyTemplate
-from traitlets import Int, observe
+from traitlets import Int, List, observe
+
+from glue.core.subset import RangeSubsetState
 
 from ...utils import load_template
 
 class PercentageSelector(VuetifyTemplate):
     
     template = load_template("percentage_selector.vue", __file__, traitlet=True).tag(sync=True)
+    options = List([50, 68, 95]).tag(sync=True)
     selected = Int().tag(sync=True)
 
-    def __init__(self, data, component_id, *args, **kwargs):
+    def __init__(self, viewer, data, component_id, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.viewer = viewer
         self.glue_data = data
         self.component_id = component_id
+        self.subset_label = kwargs.get("subset_label", None)
+        self.subset_group = kwargs.get("subset_group", False)
         self._subset = None
 
     @observe('selected')
@@ -20,10 +26,17 @@ class PercentageSelector(VuetifyTemplate):
         around_median = selected / 2
         bottom_percent = 50 - around_median
         top_percent = 50 + around_median
-        bottom = self.data.compute_statistic('percentile', self.component_id, percentile=bottom_percent)
-        top = self.data.compute_statistic('percentile', self.component_id, percentile=top_percent)
-        state = self.data[self.component_id.label] >= bottom & self.data[self.component_id.label] <= top
+        bottom = self.glue_data.compute_statistic('percentile', self.component_id, percentile=bottom_percent)
+        top = self.glue_data.compute_statistic('percentile', self.component_id, percentile=top_percent)
+        state = RangeSubsetState(bottom, top, self.component_id)
         if self._subset is None:
-            self._subset = self.data.new_subset(state)
+            kwargs = { "label": self.subset_label } if self.subset_label else {}
+            if self.subset_group:
+                self._subset = self.viewer.session.data_collection.new_subset_group(state, **kwargs)
+            else:
+                self._subset = self.glue_data.new_subset(state, **kwargs)
+                self.viewer.add_subset(self._subset)
+                print(self._subset)
+                print(self.viewer.layers)
         else:
             self._subset.subset_state = state

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -15,7 +15,7 @@ class PercentageSelector(VuetifyTemplate):
     unit = Unicode().tag(sync=True)
     was_selected = Int(allow_none=True).tag(sync=True)
 
-    _deselected_color = "#D3D3D3"
+    _deselected_color = "#a9a9a9"
 
     # Note: we pass in the data, rather than the layer itself,
     # to deal with cases where, for either setup or story reasons,

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -29,7 +29,8 @@ class PercentageSelector(VuetifyTemplate):
             self.color = kwargs["color"]
         self.subset_label = kwargs.get("subset_label", None)
         self.subset_group = kwargs.get("subset_group", False)
-        self.transform = kwargs.get("transform", None)
+        self.lower_transform = kwargs.get("lower_transform", None)
+        self.upper_transform = kwargs.get("upper_transform", None)
         self.subset = None
         if "unit" in kwargs:
             self.unit = kwargs["unit"]
@@ -73,9 +74,10 @@ class PercentageSelector(VuetifyTemplate):
         if self.bins is not None:
             bottom = next((x for x in self.bins if x > bottom), bottom)
             top = next((x for x in self.bins if x > top), top)
-        if self.transform:
-            bottom = self.transform(bottom)
-            top = self.transform(top)
+        if self.lower_transform is not None:
+            bottom = self.lower_transform(bottom)
+        if self.upper_transform is not None:
+            top = self.upper_transform(top)
         self.selected_min = bottom
         self.selected_max = top
         self._update_subset(state)

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -20,6 +20,8 @@ class PercentageSelector(VuetifyTemplate):
         self.glue_data = data
         self.component_id = component_id
         self._bins = kwargs.get("bins", None)
+        if "options" in kwargs:
+            self.options = kwargs.get("options")
         self.subset_label = kwargs.get("subset_label", None)
         self.subset_group = kwargs.get("subset_group", False)
         self.transform = kwargs.get("transform", None)

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -9,6 +9,7 @@ from ...utils import load_template
 class PercentageSelector(VuetifyTemplate):
     
     template = load_template("percentage_selector.vue", __file__, traitlet=True).tag(sync=True)
+    color = Unicode("#1e90ff").tag(sync=True)
     options = List([50, 68, 95]).tag(sync=True)
     selected = Int(allow_none=True).tag(sync=True)
     selected_min = Float().tag(sync=True)
@@ -24,6 +25,8 @@ class PercentageSelector(VuetifyTemplate):
         self._bins = kwargs.get("bins", None)
         if "options" in kwargs:
             self.options = kwargs["options"]
+        if "color" in kwargs:
+            self.color = kwargs["color"]
         self.subset_label = kwargs.get("subset_label", None)
         self.subset_group = kwargs.get("subset_group", False)
         self.transform = kwargs.get("transform", None)
@@ -41,7 +44,9 @@ class PercentageSelector(VuetifyTemplate):
 
     def _update_subset(self, state):
         if self.subset is None:
-            kwargs = { "label": self.subset_label } if self.subset_label else {}
+            kwargs = { "color": self.color }
+            if self.subset_label:
+                kwargs["label"] = self.subset_label
             if self.subset_group:
                 self.subset = self.viewer.session.data_collection.new_subset_group(state, **kwargs)
             else:

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -10,7 +10,7 @@ class PercentageSelector(VuetifyTemplate):
 
     def __init__(self, data, component_id, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.data = data
+        self.glue_data = data
         self.component_id = component_id
         self._subset = None
 

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -105,7 +105,8 @@ class PercentageSelector(VuetifyTemplate):
             viewer.figure.title = label_text
             viewer.figure.title_style = {
                 "font-size": '1rem',
-                "fill": "black"  # Since this is all happening in svg-land, use fill to set the text color
+                "fill": "black",  # Since this is all happening in svg-land, use fill to set the text color
+                "transform": "translate(0, 5px)"
             }
 
         self._update_subsets(states)

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -1,6 +1,6 @@
 from ipyvuetify import VuetifyTemplate
 from numpy import array, percentile
-from traitlets import Float, Int, List, observe
+from traitlets import Float, Int, List, Unicode, observe
 
 from glue.core.subset import RangeSubsetState
 
@@ -13,6 +13,7 @@ class PercentageSelector(VuetifyTemplate):
     selected = Int(allow_none=True).tag(sync=True)
     selected_min = Float().tag(sync=True)
     selected_max = Float().tag(sync=True)
+    unit = Unicode().tag(sync=True)
     was_selected = Int(allow_none=True).tag(sync=True)
 
     def __init__(self, viewer, data, component_id, *args, **kwargs):
@@ -22,11 +23,13 @@ class PercentageSelector(VuetifyTemplate):
         self.component_id = component_id
         self._bins = kwargs.get("bins", None)
         if "options" in kwargs:
-            self.options = kwargs.get("options")
+            self.options = kwargs["options"]
         self.subset_label = kwargs.get("subset_label", None)
         self.subset_group = kwargs.get("subset_group", False)
         self.transform = kwargs.get("transform", None)
-        self._subset = None
+        self.subset = None
+        if "unit" in kwargs:
+            self.unit = kwargs["unit"]
 
     @property
     def bins(self):
@@ -37,15 +40,15 @@ class PercentageSelector(VuetifyTemplate):
         return None
 
     def _update_subset(self, state):
-        if self._subset is None:
+        if self.subset is None:
             kwargs = { "label": self.subset_label } if self.subset_label else {}
             if self.subset_group:
-                self._subset = self.viewer.session.data_collection.new_subset_group(state, **kwargs)
+                self.subset = self.viewer.session.data_collection.new_subset_group(state, **kwargs)
             else:
-                self._subset = self.glue_data.new_subset(state, **kwargs)
-                self.viewer.add_subset(self._subset)
+                self.subset = self.glue_data.new_subset(state, **kwargs)
+                self.viewer.add_subset(self.subset)
         else:
-            self._subset.subset_state = state
+            self.subset.subset_state = state
 
     @observe('selected')
     def _update(self, change):

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -111,9 +111,9 @@ class PercentageSelector(VuetifyTemplate):
                 unit_str = f" {self.units[index]}"
             else:
                 unit_str = ""
-            label_text = f"{bottom}{unit_str} - {top}{unit_str}"
+            label_text = f"{selected}%: {bottom} - {top}{unit_str}"
             viewer.figure.title = label_text
-            viewer.figure.title_style = { "font-size": '20pt', "color": f"{self._original_colors[index]}" }
+            viewer.figure.title_style = { "font-size": '1rem', "color": f"{self._original_colors[index]}" }
 
         self._update_subsets(states)
 

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -1,0 +1,29 @@
+from ipyvuetify import VuetifyTemplate
+from traitlets import Int, observe
+
+from ...utils import load_template
+
+class PercentageSelector(VuetifyTemplate):
+    
+    template = load_template("percentage_selector.vue", __file__, traitlet=True).tag(sync=True)
+    selected = Int().tag(sync=True)
+
+    def __init__(self, data, component_id, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.data = data
+        self.component_id = component_id
+        self._subset = None
+
+    @observe('selected')
+    def _update_subset(self, change):
+        selected = change["new"]
+        around_median = selected / 2
+        bottom_percent = 50 - around_median
+        top_percent = 50 + around_median
+        bottom = self.data.compute_statistic('percentile', self.component_id, percentile=bottom_percent)
+        top = self.data.compute_statistic('percentile', self.component_id, percentile=top_percent)
+        state = self.data[self.component_id.label] >= bottom & self.data[self.component_id.label] <= top
+        if self._subset is None:
+            self._subset = self.data.new_subset(state)
+        else:
+            self._subset.subset_state = state

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -25,23 +25,15 @@ class PercentageSelector(VuetifyTemplate):
         super().__init__(*args, **kwargs)
         self.viewers = viewers
         self.glue_data = data
-        self._bins = kwargs.get("bins", None)
         self._original_colors = []
+        self.resolution = kwargs.get("resolution", None)  # Number of decimal places for reporting bounds
         if "options" in kwargs:
             self.options = kwargs["options"]
         self.subset_labels = kwargs.get("subset_labels", [])
         self.subset_group = kwargs.get("subset_group", False)
-        self.lower_transform = kwargs.get("lower_transform", None)
-        self.upper_transform = kwargs.get("upper_transform", None)
         self.subsets = []
         if "units" in kwargs:
             self.units = kwargs["units"]
-
-    @property
-    def bins(self):
-        if self._bins is not None:
-            return self._bins
-        return [getattr(viewer.state, "bins", None) for viewer in self.viewers]
 
     def _update_subsets(self, states):
         if not self.subsets:
@@ -99,21 +91,22 @@ class PercentageSelector(VuetifyTemplate):
             top = percentile(data, top_percent, method="nearest")
             state = RangeSubsetState(bottom, top, component_id)
             states.append(state)
-            bins = self.bins[index]
-            if bins is not None:
-                bottom = next((x for x in bins if x > bottom), bottom)
-                top = next((x for x in bins if x > top), top)
-            if self.lower_transform is not None:
-                bottom = self.lower_transform(bottom)
-            if self.upper_transform is not None:
-                top = self.upper_transform(top)
+            if self.resolution is not None:
+                bottom = round(bottom, self.resolution)
+                top = round(top, self.resolution)
+
+            bottom_str = "{:g}".format(bottom)
+            top_str = "{:g}".format(top)
             if self.units and self.units[index]:
                 unit_str = f" {self.units[index]}"
             else:
                 unit_str = ""
-            label_text = f"{selected}%: {bottom} - {top}{unit_str}"
+            label_text = f"{selected}%: {bottom_str} - {top_str}{unit_str}"
             viewer.figure.title = label_text
-            viewer.figure.title_style = { "font-size": '1rem', "color": f"{self._original_colors[index]}" }
+            viewer.figure.title_style = {
+                "font-size": '1rem',
+                "fill": "black"  # Since this is all happening in svg-land, use fill to set the text color
+            }
 
         self._update_subsets(states)
 

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -1,5 +1,5 @@
 from ipyvuetify import VuetifyTemplate
-from numpy import percentile
+from numpy import array, percentile
 from traitlets import Float, Int, List, observe
 
 from glue.core.subset import RangeSubsetState
@@ -10,9 +10,10 @@ class PercentageSelector(VuetifyTemplate):
     
     template = load_template("percentage_selector.vue", __file__, traitlet=True).tag(sync=True)
     options = List([50, 68, 95]).tag(sync=True)
-    selected = Int().tag(sync=True)
+    selected = Int(allow_none=True).tag(sync=True)
     selected_min = Float().tag(sync=True)
     selected_max = Float().tag(sync=True)
+    was_selected = Int(allow_none=True).tag(sync=True)
 
     def __init__(self, viewer, data, component_id, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -35,25 +36,7 @@ class PercentageSelector(VuetifyTemplate):
             return self.viewer.state.bins
         return None
 
-    @observe('selected')
-    def _update_subset(self, change):
-        selected = change["new"]
-        around_median = selected / 2
-        bottom_percent = 50 - around_median
-        top_percent = 50 + around_median
-        data = self.glue_data[self.component_id]
-        bottom = percentile(data, bottom_percent, method="nearest")
-        top = percentile(data, top_percent, method="nearest")
-        state = RangeSubsetState(bottom, top, self.component_id)
-        if self.bins is not None:
-            print(self.bins)
-            bottom = next((x for x in self.bins if x > bottom), bottom)
-            top = next((x for x in self.bins if x > top), top)
-        if self.transform:
-            bottom = self.transform(bottom)
-            top = self.transform(top)
-        self.selected_min = bottom
-        self.selected_max = top
+    def _update_subset(self, state):
         if self._subset is None:
             kwargs = { "label": self.subset_label } if self.subset_label else {}
             if self.subset_group:
@@ -63,3 +46,28 @@ class PercentageSelector(VuetifyTemplate):
                 self.viewer.add_subset(self._subset)
         else:
             self._subset.subset_state = state
+
+    @observe('selected')
+    def _update(self, change):
+        selected = change["new"]
+        if selected is None:
+            state = array([False for _ in range(self.glue_data.size)])
+            self._update_subset(state)
+            return
+
+        around_median = selected / 2
+        bottom_percent = 50 - around_median
+        top_percent = 50 + around_median
+        data = self.glue_data[self.component_id]
+        bottom = percentile(data, bottom_percent, method="nearest")
+        top = percentile(data, top_percent, method="nearest")
+        state = RangeSubsetState(bottom, top, self.component_id)
+        if self.bins is not None:
+            bottom = next((x for x in self.bins if x > bottom), bottom)
+            top = next((x for x in self.bins if x > top), top)
+        if self.transform:
+            bottom = self.transform(bottom)
+            top = self.transform(top)
+        self.selected_min = bottom
+        self.selected_max = top
+        self._update_subset(state)

--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -23,8 +23,9 @@
 export default {
   methods: {
     optionText(option) {
+      const unitStr = this.unit ? ` ${this.unit}` : "";
       if (option === this.selected) {
-        return `${option}%: ${this.selected_min} - ${this.selected_max}`;
+        return `${option}%: ${this.selected_min}${unitStr} - ${this.selected_max}${unitStr}`;
       } else {
         return `${option}%`;
       }

--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -1,9 +1,7 @@
 <template>
   <v-card
     flat
-    light
     variant="outlined"
-    color="white"
     class="percentage-selector"
   >
     <v-radio-group
@@ -14,13 +12,8 @@
         v-for="(option, index) in options"
         :key="index"
         :value="option"
+        :label="`${option}%`"
       >
     </v-radio-group>
   </v-card>
 </template>
-
-<style scoped>
-.v-card {
-  border: solid 1px black !important;
-}
-</style>

--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -12,8 +12,8 @@
         v-for="(option, index) in options"
         :key="index"
         :value="option"
-        :label="optionText(option)"
-        :color="color"
+        :label="`${option}%`"
+        :color="radio_color"
         @click.native.stop.prevent="resetIfNeeded(option)"
       >
       </v-radio>
@@ -24,14 +24,6 @@
 <script>
 export default {
   methods: {
-    optionText(option) {
-      const unitStr = this.unit ? ` ${this.unit}` : "";
-      if (option === this.selected) {
-        return `${option}%: ${this.selected_min}${unitStr} - ${this.selected_max}${unitStr}`;
-      } else {
-        return `${option}%`;
-      }
-    },
     resetIfNeeded(value) {
       this.was_selected = (this.was_selected === value) ? null : value;
       this.selected = this.was_selected;

--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -12,10 +12,49 @@
         v-for="(option, index) in options"
         :key="index"
         :value="option"
-        :label="`${option}%`"
         :color="radio_color"
         @click.native.stop.prevent="resetIfNeeded(option)"
       >
+        <template v-slot:label>
+          <span>{{ `${option}%` }}</span>
+          <v-dialog content-class="percentage-help-dialog">
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn
+                icon
+                v-on="on"
+                v-bind="attrs"
+              >
+                <v-icon small>mdi-help</v-icon>
+              </v-btn>
+            </template>
+            <v-card
+              class="mx-auto"
+            >
+              <v-toolbar
+                color="secondary"
+                dense
+                dark
+              >
+                <v-toolbar-title
+                  class="text-h6 text-uppercase font-weight-regular"
+                >
+                {{ `${option}% of the data` }}
+                </v-toolbar-title>
+                <v-spacer></v-spacer>
+              </v-toolbar>
+              <div>
+                {{ 
+                  `
+                  The range of values shown are the inner ${option}% of data points. 
+                  This means that ${option/2}% of the data points in the distribution 
+                  have values less than this range, and ${option/2}% of the data points 
+                  have values greater than this range.
+                  `
+                }}
+              </div>
+            </v-card>
+          </v-dialog>
+        </template>
       </v-radio>
     </v-radio-group>
   </v-card>
@@ -39,5 +78,9 @@ export default {
 
 .v-radio .v-input--selection-controls__input {
   pointer-events: auto;
+}
+
+.percentage-help-dialog {
+  width: 67% !important;
 }
 </style>

--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -1,0 +1,39 @@
+<template>
+  <v-card
+    flat
+    light
+    variant="outlined"
+    color="white"
+    class="percentage-selector"
+  >
+    <v-radio-group
+      v-model="selected"
+      column
+    >
+      <v-radio
+        v-for="(option, index) in options"
+        :key="index"
+        :value="option"
+      >
+    </v-radio-group>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: {
+    options: {
+      validator(value) {
+        return Array.isArray(value) && value.every(x => typeof x === "number");
+      },
+      required: true
+    }
+  } 
+}
+</script>
+
+<style scoped>
+.v-card {
+  border: solid 1px black !important;
+}
+</style>

--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -46,8 +46,8 @@
                 {{ 
                   `
                   The range of values shown are the inner ${option}% of data points. 
-                  This means that ${option/2}% of the data points in the distribution 
-                  have values less than this range, and ${option/2}% of the data points 
+                  This means that ${(100-option)/2}% of the data points in the distribution 
+                  have values less than this range, and ${(100-option)/2}% of the data points 
                   have values greater than this range.
                   `
                 }}

--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -12,8 +12,22 @@
         v-for="(option, index) in options"
         :key="index"
         :value="option"
-        :label="`${option}%`"
+        :label="optionText(option)"
       >
     </v-radio-group>
   </v-card>
 </template>
+
+<script>
+export default {
+  methods: {
+    optionText(option) {
+      if (option === this.selected) {
+        return `${option}%: ${this.selected_min} - ${this.selected_max}`;
+      } else {
+        return `${option}%`;
+      }
+    }
+  }
+}
+</script>

--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -13,6 +13,7 @@
         :key="index"
         :value="option"
         :label="optionText(option)"
+        @click.native.stop.prevent="resetIfNeeded(option)"
       >
     </v-radio-group>
   </v-card>
@@ -27,7 +28,21 @@ export default {
       } else {
         return `${option}%`;
       }
+    },
+    resetIfNeeded(value) {
+      this.was_selected = (this.was_selected === value) ? null : value;
+      this.selected = this.was_selected;
     }
   }
 }
 </script>
+
+<style scoped>
+.v-radio {
+  pointer-events: none;
+}
+
+.v-radio .v-input--selection-controls__input {
+  pointer-events: auto;
+}
+</style>

--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -19,19 +19,6 @@
   </v-card>
 </template>
 
-<script>
-export default {
-  props: {
-    options: {
-      validator(value) {
-        return Array.isArray(value) && value.every(x => typeof x === "number");
-      },
-      required: true
-    }
-  } 
-}
-</script>
-
 <style scoped>
 .v-card {
   border: solid 1px black !important;

--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -13,8 +13,10 @@
         :key="index"
         :value="option"
         :label="optionText(option)"
+        :color="color"
         @click.native.stop.prevent="resetIfNeeded(option)"
       >
+      </v-radio>
     </v-radio-group>
   </v-card>
 </template>

--- a/cosmicds/components/statistics_selector/__init__.py
+++ b/cosmicds/components/statistics_selector/__init__.py
@@ -1,0 +1,1 @@
+from .statistics_selector import StatisticsSelector

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -1,0 +1,37 @@
+from ipyvuetify import VuetifyTemplate
+from traitlets import List, observe
+
+from ...utils import load_template, vertical_line_mark
+
+class StatisticsSelector(VuetifyTemplate):
+
+    template = load_template("statistics_selector.vue", __file__, traitlet=True).tag(sync=True)
+    selected = List().tag(sync=True)
+    statistics = List().tag(sync=True)
+    colors = List(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).tag(sync=True)
+
+    def __init__(self, viewer, data, component_id, layer, statistics=['mean', 'median', 'mode'], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.viewer = viewer
+        self.data = data
+        self.component_id = component_id
+        self.layer = layer
+        self.statistics = statistics
+        self._lines = []
+
+    @observe('selected')
+    def _update_marks(self, change):
+        selected = change["new"]
+        marks = [mark for mark in self.viewer.figure.marks if mark not in self._lines]
+        lines = []
+        for index, stat in enumerate(self.statistics):
+            try:
+                value = self.data.compute_statistic(stat, self.component_id)
+                mark = vertical_line_mark(self.layer, value, self.colors[index])
+                lines.append(mark)
+            except ValueError:
+                continue
+
+        self.viewer.figure.marks = marks + lines
+        self._lines = lines
+

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -26,6 +26,7 @@ class StatisticsSelector(VuetifyTemplate):
         if "unit" in kwargs:
             self.unit = kwargs["unit"]
         self._lines = []
+        self.viewer.figure.observe(self._on_marks_updated, names=["marks"])
 
     def _mode(self):
         data = self.glue_data[self.component_id]
@@ -56,6 +57,13 @@ class StatisticsSelector(VuetifyTemplate):
         if hasattr(self.viewer.state, "bins"):
             return self.viewer.state.bins
         return None
+
+    # This is a bit of a hack to prevent layer artists from
+    # redrawing their marks without ours included
+    def _on_marks_updated(self, _marks):
+        if not all(line in self.viewer.figure.marks for line in self._lines):
+            other_marks = [mark for mark in self.viewer.figure.marks if mark not in self._lines]
+            self.viewer.figure.marks = other_marks + self._lines
 
     @observe('selected')
     def _update_marks(self, change):

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -12,12 +12,13 @@ class StatisticsSelector(VuetifyTemplate):
     statistics = List().tag(sync=True)
     colors = List(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).tag(sync=True)
 
-    def __init__(self, viewer, data, component_id, layer, bins=None, statistics=['mean', 'median', 'mode'], *args, **kwargs):
+    def __init__(self, viewer, data, component_id, layer, transform=None, bins=None, statistics=['mean', 'median', 'mode'], *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.viewer = viewer
         self.glue_data = data
         self.component_id = component_id
         self.layer = layer
+        self.transform = transform
         self.statistics = statistics
         self._bins = bins
         if "colors" in kwargs:
@@ -26,7 +27,7 @@ class StatisticsSelector(VuetifyTemplate):
 
     def _mode(self):
         data = self.glue_data[self.component_id]
-        if self.bins:
+        if self.bins is not None:
             hist, bins = histogram(data, bins=self.bins)
             idx = argmax(hist)
             return 0.5 * (bins[idx] + bins[idx + 1])
@@ -61,6 +62,8 @@ class StatisticsSelector(VuetifyTemplate):
                continue 
             try:
                 value = self._find_statistic(stat)
+                if self.transform is not None:
+                    value = self.transform(value)
                 label = f"{stat.capitalize()}: {value}"
                 mark = vertical_line_mark(self.layer, value, self.colors[index],
                                           label=label, label_visibility="none")

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -1,7 +1,7 @@
 from collections import Counter
 from ipyvuetify import VuetifyTemplate
 from numpy import argmax, histogram
-from traitlets import List, observe
+from traitlets import List, Unicode, observe
 
 from ...utils import load_template, vertical_line_mark
 
@@ -11,17 +11,20 @@ class StatisticsSelector(VuetifyTemplate):
     selected = List().tag(sync=True)
     statistics = List().tag(sync=True)
     colors = List(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).tag(sync=True)
+    unit = Unicode().tag(sync=True)
 
-    def __init__(self, viewer, data, component_id, transform=None, bins=None, statistics=['mean', 'median', 'mode'], *args, **kwargs):
+    def __init__(self, viewer, data, component_id, statistics=['mean', 'median', 'mode'], *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.viewer = viewer
         self.glue_data = data
         self.component_id = component_id
-        self.transform = transform
         self.statistics = statistics
-        self._bins = bins
+        self.transform = kwargs.get("transform", None)
+        self._bins = kwargs.get("bins", None)
         if "colors" in kwargs:
-            self.colors = kwargs.get("colors")
+            self.colors = kwargs["colors"]
+        if "unit" in kwargs:
+            self.unit = kwargs["unit"]
         self._lines = []
 
     def _mode(self):
@@ -64,6 +67,8 @@ class StatisticsSelector(VuetifyTemplate):
                 if self.transform is not None:
                     value = self.transform(value)
                 label = f"{stat.capitalize()}: {value}"
+                if self.unit:
+                    label += f" {self.unit}"
                 mark = vertical_line_mark(self.viewer.layers[0], value, self.colors[index],
                                           label=label, label_visibility="none")
                 lines.append(mark)

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -13,7 +13,7 @@ class StatisticsSelector(VuetifyTemplate):
     def __init__(self, viewer, data, component_id, layer, statistics=['mean', 'median', 'mode'], *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.viewer = viewer
-        self.data = data
+        self.glue_data = data
         self.component_id = component_id
         self.layer = layer
         self.statistics = statistics
@@ -24,9 +24,11 @@ class StatisticsSelector(VuetifyTemplate):
         selected = change["new"]
         marks = [mark for mark in self.viewer.figure.marks if mark not in self._lines]
         lines = []
-        for index, stat in enumerate(selected):
+        for index, stat in enumerate(self.statistics):
+            if index not in selected:
+               continue 
             try:
-                value = self.data.compute_statistic(stat, self.component_id)
+                value = self.glue_data.compute_statistic(stat, self.component_id)
                 mark = vertical_line_mark(self.layer, value, self.colors[index])
                 lines.append(mark)
             except ValueError:

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -9,7 +9,7 @@ class StatisticsSelector(VuetifyTemplate):
 
     template = load_template("statistics_selector.vue", __file__, traitlet=True).tag(sync=True)
     color = Unicode("#1e90ff").tag(sync=True)
-    selected = Unicode(allow_none=True).tag(sync=True)
+    selected = Unicode(None, allow_none=True).tag(sync=True)
     statistics = List().tag(sync=True)
     unit = Unicode().tag(sync=True)
     was_selected = Unicode(allow_none=True).tag(sync=True)
@@ -26,75 +26,93 @@ class StatisticsSelector(VuetifyTemplate):
         "median": "path to median image"
     }).tag(sync=True)
 
-    def __init__(self, viewer, data, component_id, statistics=['mean', 'median', 'mode'], *args, **kwargs):
+    def __init__(self, viewers, data, statistics=['mean', 'median', 'mode'], *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.viewer = viewer
+        self.viewers = viewers
         self.glue_data = data
-        self.component_id = component_id
         self.statistics = statistics
         self.transform = kwargs.get("transform", None)
         self._bins = kwargs.get("bins", None)
-        self._line = None
+        self.lines = []
         if "color" in kwargs:
             self.color = kwargs["color"]
-        if "unit" in kwargs:
-            self.unit = kwargs["unit"]
-        self.viewer.figure.observe(self._on_marks_updated, names=["marks"])
+        if "units" in kwargs:
+            self.units = kwargs["units"]
+        for (index, viewer) in enumerate(self.viewers):
+            viewer.figure.observe(lambda _change: self._on_marks_updated(index), names=["marks"])
 
-    def _mode(self):
-        data = self.glue_data[self.component_id]
-        if self.bins is not None:
-            hist, bins = histogram(data, bins=self.bins)
+    def _mode(self, viewer, data, bins):
+        component_id = viewer.state.x_att
+        values = data[component_id]
+        if bins is not None:
+            hist, hbins = histogram(values, bins=bins)
             indices = flatnonzero(hist == amax(hist)) 
-            return [0.5 * (bins[idx] + bins[idx + 1]) for idx in indices]
+            return [0.5 * (hbins[idx] + hbins[idx + 1]) for idx in indices]
         else:
             counter = Counter(data)
             max_count = counter.most_common(1)[0][1]
             return [k for k, v in counter.items() if v == max_count]
 
-    def _glue_statistic(self, stat):
-        return self.glue_data.compute_statistic(stat, self.component_id)
-
     # glue doesn't implement a mode statistic, so we roll our own
     # Since there can be multiple modes, mode can be a list
     # and so we return a list for every statistic to make things simpler
-    def _find_statistic(self, stat):
+    def _find_statistic(self, stat, viewer, data, bins):
         if stat == 'mode':
-            return self._mode()
-        return [self._glue_statistic(stat)]
+            return self._mode(viewer, data, bins)
+        else:
+            return [data.compute_statistic(stat, viewer.state.x_att)]
 
     @property
     def bins(self):
         if self._bins is not None:
             return self._bins
-        if hasattr(self.viewer.state, "bins"):
-            return self.viewer.state.bins
-        return None
+        return [getattr(viewer.state, "bins", None) for viewer in self.viewers] 
 
     # This is a bit of a hack to prevent layer artists from
     # redrawing their marks without ours included
-    def _on_marks_updated(self, _marks):
-        if self._line is not None and self._line not in self.viewer.figure.marks:
-            self.viewer.figure.marks = self.viewer.figure.marks + [self._line]
+    def _on_marks_updated(self, index):
+        if not self.lines:
+            return
+        line = self.lines[index]
+        viewer = self.viewers[index]
+        if line is not None and line not in viewer.figure.marks:
+            viewer.figure.marks = viewer.figure.marks + [line]
+
+    def _remove_lines(self):
+        if self.lines:
+            # Do this first so that _on_marks_updated doesn't redraw the lines
+            lines = self.lines
+            self.lines = []
+            
+            for (viewer, line) in zip(self.viewers, lines):
+                viewer.figure.marks = [m for m in viewer.figure.marks if m is not line]
 
     @observe('selected')
     def _update_marks(self, change):
         selected = change["new"]
-        marks = [mark for mark in self.viewer.figure.marks if mark is not self._line]
-        try:
-            values = self._find_statistic(selected)
-            if self.transform is not None:
-                values = [self.transform(v) for v in values]
-            for value in values:
-                label = f"{selected.capitalize()}: {value}"
-                if self.unit:
-                    label += f" {self.unit}"
-                line = vertical_line_mark(self.viewer.layers[0], value, self.color,
-                                      label=label, label_visibility="none")
-        except ValueError:
-            line = None 
+        self._remove_lines()
 
-        self._line = line
-        line_mark_list = [line] if line is not None else []
-        self.viewer.figure.marks = marks + line_mark_list
+        if selected is None:
+            return
+
+        lines = []
+        for viewer, data, bins in zip(self.viewers, self.glue_data, self.bins):
+            try:
+                values = self._find_statistic(selected, viewer, data, bins)
+                if self.transform is not None:
+                    values = [self.transform(v) for v in values]
+                for value in values:
+                    label = f"{selected.capitalize()}: {value}"
+                    if self.unit:
+                        label += f" {self.unit}"
+                    line = vertical_line_mark(viewer.layers[0], value, self.color,
+                                          label=label, label_visibility="none")
+            except ValueError:
+                line = None 
+
+            lines.append(line)
+            line_mark_list = [line] if line is not None else []
+            viewer.figure.marks = viewer.figure.marks + line_mark_list
+
+        self.lines = lines
 

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -12,12 +12,11 @@ class StatisticsSelector(VuetifyTemplate):
     statistics = List().tag(sync=True)
     colors = List(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).tag(sync=True)
 
-    def __init__(self, viewer, data, component_id, layer, transform=None, bins=None, statistics=['mean', 'median', 'mode'], *args, **kwargs):
+    def __init__(self, viewer, data, component_id, transform=None, bins=None, statistics=['mean', 'median', 'mode'], *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.viewer = viewer
         self.glue_data = data
         self.component_id = component_id
-        self.layer = layer
         self.transform = transform
         self.statistics = statistics
         self._bins = bins
@@ -65,7 +64,7 @@ class StatisticsSelector(VuetifyTemplate):
                 if self.transform is not None:
                     value = self.transform(value)
                 label = f"{stat.capitalize()}: {value}"
-                mark = vertical_line_mark(self.layer, value, self.colors[index],
+                mark = vertical_line_mark(self.viewer.layers[0], value, self.colors[index],
                                           label=label, label_visibility="none")
                 lines.append(mark)
             except ValueError:

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -24,7 +24,7 @@ class StatisticsSelector(VuetifyTemplate):
         selected = change["new"]
         marks = [mark for mark in self.viewer.figure.marks if mark not in self._lines]
         lines = []
-        for index, stat in enumerate(self.statistics):
+        for index, stat in enumerate(selected):
             try:
                 value = self.data.compute_statistic(stat, self.component_id)
                 mark = vertical_line_mark(self.layer, value, self.colors[index])

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -1,7 +1,7 @@
 from collections import Counter
 from ipyvuetify import VuetifyTemplate
 from numpy import amax, flatnonzero, histogram
-from traitlets import List, Unicode, observe
+from traitlets import Dict, List, Unicode, observe
 
 from ...utils import load_template, vertical_line_mark
 
@@ -13,6 +13,18 @@ class StatisticsSelector(VuetifyTemplate):
     statistics = List().tag(sync=True)
     unit = Unicode().tag(sync=True)
     was_selected = Unicode(allow_none=True).tag(sync=True)
+
+    help_text = Dict({
+        "mode": "Description of the mode",
+        "mean": "Description of the mean",
+        "median": "Description of the median"
+    }).tag(sync=True)
+
+    help_images = Dict({
+        "mode": "path to mode image",
+        "mean": "path to mean image",
+        "median": "path to median image"
+    }).tag(sync=True)
 
     def __init__(self, viewer, data, component_id, statistics=['mean', 'median', 'mode'], *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -11,7 +11,6 @@ class StatisticsSelector(VuetifyTemplate):
     color = Unicode("#1e90ff").tag(sync=True)
     selected = Unicode(None, allow_none=True).tag(sync=True)
     statistics = List().tag(sync=True)
-    unit = Unicode().tag(sync=True)
     was_selected = Unicode(allow_none=True).tag(sync=True)
 
     help_text = Dict({
@@ -96,15 +95,15 @@ class StatisticsSelector(VuetifyTemplate):
             return
 
         lines = []
-        for viewer, data, bins in zip(self.viewers, self.glue_data, self.bins):
+        for viewer, data, bins, unit in zip(self.viewers, self.glue_data, self.bins, self.units):
             try:
                 values = self._find_statistic(selected, viewer, data, bins)
                 if self.transform is not None:
                     values = [self.transform(v) for v in values]
                 for value in values:
                     label = f"{selected.capitalize()}: {value}"
-                    if self.unit:
-                        label += f" {self.unit}"
+                    if unit:
+                        label += f" {unit}"
                     line = vertical_line_mark(viewer.layers[0], value, self.color,
                                           label=label, label_visibility="none")
             except ValueError:

--- a/cosmicds/components/statistics_selector/statistics_selector.vue
+++ b/cosmicds/components/statistics_selector/statistics_selector.vue
@@ -17,7 +17,7 @@
       >
         <template v-slot:label>
           <span>{{ capitalizeFirstLetter(stat) }}</span>
-          <v-dialog>
+          <v-dialog class="help-dialog">
             <template v-slot:activator="{ on, attrs }">
               <v-btn
                 icon
@@ -28,7 +28,7 @@
               </v-btn>
             </template>
             <v-card
-              class="mx-auto help-card"
+              class="mx-auto"
             >
               <v-toolbar
                 color="secondary"
@@ -82,7 +82,7 @@ export default {
   pointer-events: auto;
 }
 
-.help-card {
+.help-dialog {
   width: fit-content !important;
 }
 

--- a/cosmicds/components/statistics_selector/statistics_selector.vue
+++ b/cosmicds/components/statistics_selector/statistics_selector.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-card
+    flat
+    light
+    variant="outlined"
+    color="white"
+    class="statistics-selector"
+  >
+    <v-list-item-group
+      multiple
+      v-model="selected"
+    >
+      <v-list-item
+        v-for="(stat, index) in statistics"
+        :key="index"
+        :value="stat"
+        inactive
+      >
+        <template v-slot:default="{ active }">
+          <v-list-item-content
+            class="font-weight-bold"
+          >
+            {{ capitalizeFirstLetter(stat) }}
+          </v-list-item-content>
+
+          <v-list-item-action>
+            <v-checkbox
+              :input-value="active"
+              :color="colors[index]"
+            />
+          </v-list-item-action>
+        </template>
+      </v-list-item>
+    </v-list-item-group>
+  </v-card>
+</template>
+
+<script>
+export default {
+  methods: {
+    capitalizeFirstLetter(text) {
+      return text.charAt(0).toUpperCase() + text.slice(1);
+    }
+  }
+}
+</script>

--- a/cosmicds/components/statistics_selector/statistics_selector.vue
+++ b/cosmicds/components/statistics_selector/statistics_selector.vue
@@ -4,32 +4,20 @@
     variant="outlined"
     class="statistics-selector"
   >
-    <v-list-item-group
-      multiple
+    <v-radio-group
       v-model="selected"
+      column
     >
-      <v-list-item
+      <v-radio
         v-for="(stat, index) in statistics"
         :key="index"
         :value="stat"
-        inactive
+        :label="capitalizeFirstLetter(stat)"
+        :color="color"
+        @click.native.stop.prevent="resetIfNeeded(stat)"
       >
-        <template v-slot:default="{ active }">
-          <v-list-item-content
-            class="font-weight-bold"
-          >
-            {{ capitalizeFirstLetter(stat) }}
-          </v-list-item-content>
-
-          <v-list-item-action>
-            <v-checkbox
-              :input-value="active"
-              :color="colors[index]"
-            />
-          </v-list-item-action>
-        </template>
-      </v-list-item>
-    </v-list-item-group>
+      </v-radio>
+    </v-radio-group>
   </v-card>
 </template>
 
@@ -38,7 +26,21 @@ export default {
   methods: {
     capitalizeFirstLetter(text) {
       return text.charAt(0).toUpperCase() + text.slice(1);
+    },
+    resetIfNeeded(value) {
+      this.was_selected = (this.was_selected === value) ? null : value;
+      this.selected = this.was_selected;
     }
   }
 }
 </script>
+
+<style scoped>
+.v-radio {
+  pointer-events: none;
+}
+
+.v-radio .v-input--selection-controls__input {
+  pointer-events: auto;
+}
+</style>

--- a/cosmicds/components/statistics_selector/statistics_selector.vue
+++ b/cosmicds/components/statistics_selector/statistics_selector.vue
@@ -17,7 +17,7 @@
       >
         <template v-slot:label>
           <span>{{ capitalizeFirstLetter(stat) }}</span>
-          <v-dialog class="help-dialog">
+          <v-dialog content-class="stat-help-dialog">
             <template v-slot:activator="{ on, attrs }">
               <v-btn
                 icon
@@ -42,7 +42,7 @@
                 </v-toolbar-title>
                 <v-spacer></v-spacer>
               </v-toolbar>
-              <div class="help-content">
+              <div class="stat-help-content">
                 <div>{{ help_text[stat] }}</div>
                 <v-img
                   :src="help_images[stat]"
@@ -82,11 +82,11 @@ export default {
   pointer-events: auto;
 }
 
-.help-dialog {
+.stat-help-dialog {
   width: fit-content !important;
 }
 
-.help-content {
+.stat-help-content {
   display: grid;
   grid-template-rows: 1fr;
   grid-template-columns: 2fr 1fr;

--- a/cosmicds/components/statistics_selector/statistics_selector.vue
+++ b/cosmicds/components/statistics_selector/statistics_selector.vue
@@ -12,10 +12,46 @@
         v-for="(stat, index) in statistics"
         :key="index"
         :value="stat"
-        :label="capitalizeFirstLetter(stat)"
         :color="color"
         @click.native.stop.prevent="resetIfNeeded(stat)"
       >
+        <template v-slot:label>
+          <span>{{ capitalizeFirstLetter(stat) }}</span>
+          <v-dialog>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn
+                icon
+                v-on="on"
+                v-bind="attrs"
+              >
+                <v-icon small>mdi-help</v-icon>
+              </v-btn>
+            </template>
+            <v-card
+              class="mx-auto help-card"
+            >
+              <v-toolbar
+                color="secondary"
+                dense
+                dark
+              >
+                <v-toolbar-title
+                  class="text-h6 text-uppercase font-weight-regular"
+                >
+                  {{ stat }}
+                </v-toolbar-title>
+                <v-spacer></v-spacer>
+              </v-toolbar>
+              <div class="help-content">
+                <div>{{ help_text[stat] }}</div>
+                <v-img
+                  :src="help_images[stat]"
+                  placeholder="https://dummyimage.com/640x360/fff/aaa"
+                ></v-img>
+              </div>
+            </v-card>
+          </v-dialog>
+        </template>
       </v-radio>
     </v-radio-group>
   </v-card>
@@ -40,7 +76,19 @@ export default {
   pointer-events: none;
 }
 
-.v-radio .v-input--selection-controls__input {
+.v-radio .v-input--selection-controls__input,
+.v-btn
+{
   pointer-events: auto;
+}
+
+.help-card {
+  width: fit-content !important;
+}
+
+.help-content {
+  display: grid;
+  grid-template-rows: 1fr;
+  grid-template-columns: 2fr 1fr;
 }
 </style>

--- a/cosmicds/components/statistics_selector/statistics_selector.vue
+++ b/cosmicds/components/statistics_selector/statistics_selector.vue
@@ -1,9 +1,7 @@
 <template>
   <v-card
     flat
-    light
     variant="outlined"
-    color="white"
     class="statistics-selector"
   >
     <v-list-item-group

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -5,6 +5,7 @@ from math import log10
 from astropy.modeling import models, fitting
 from bqplot.marks import Lines
 from bqplot.scales import LinearScale
+from glue.viewers.common.viewer import LayerArtist
 from glue_jupyter.bqplot.common import BqplotBaseView
 from glue_jupyter.bqplot.histogram import BqplotHistogramLayerArtist
 from glue_jupyter.bqplot.scatter import BqplotScatterLayerArtist
@@ -261,7 +262,7 @@ def line_mark(has_scales, start_x, start_y, end_x, end_y, color, label=None):
                    display_legend=label is not None,
                    labels_visibility='label')
 
-def vertical_line_mark(layer, x, color, label=None):
+def vertical_line_mark(has_scales, x, color, label=None):
     """
     A specialization of `line_mark` specifically for vertical lines.
     Parameters
@@ -273,8 +274,11 @@ def vertical_line_mark(layer, x, color, label=None):
     color : str
         The desired color of the line, represented as a hex string.
     """
-    viewer_state = layer.state.viewer_state
-    return line_mark(layer, x, viewer_state.y_min, x, viewer_state.y_max, color, label)
+    if isinstance(has_scales, LayerArtist):
+        viewer_state = has_scales.state.viewer_state
+    elif isinstance(has_scales, BqplotBaseView):
+        viewer_state = has_scales.state
+    return line_mark(has_scales, x, viewer_state.y_min, x, viewer_state.y_max, color, label)
 
 # Taken from https://jonlabelle.com/snippets/view/python/python-debounce-decorator-function
 def debounce(wait):

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -223,7 +223,7 @@ def fit_line(x, y):
     fitted_line = fit(line_init, x, y)
     return fitted_line
 
-def line_mark(has_scales, start_x, start_y, end_x, end_y, color, label=None, label_visibility=None):
+def line_mark(layer, start_x, start_y, end_x, end_y, color, label=None, label_visibility=None):
     """
     Creates a Lines mark between the given start and end points
     using the scales of the given layer.
@@ -242,18 +242,10 @@ def line_mark(has_scales, start_x, start_y, end_x, end_y, color, label=None, lab
     color : str
         The desired color of the line, represented as a hex string.
     """
-    if isinstance(has_scales, BqplotScatterLayerArtist):
-        scales = has_scales.image.scales
-    elif isinstance(has_scales, BqplotHistogramLayerArtist):
-        layer_scales = has_scales.view.scales
-        layer_x = layer_scales['x']
-        layer_y = layer_scales['y']
-        scales = {
-            'x': LinearScale(min=layer_x.min, max=layer_x.max, allow_padding=layer_x.allow_padding),
-            'y': LinearScale(min=layer_y.min, max=layer_y.max, allow_padding=layer_y.allow_padding),
-        }
-    elif isinstance(has_scales, BqplotBaseView):
-        scales = has_scales.scales
+    if isinstance(layer, BqplotScatterLayerArtist):
+        scales = layer.image.scales
+    elif isinstance(layer, BqplotHistogramLayerArtist):
+        scales = layer.view.scales
     return Lines(x=[start_x, end_x],
                  y=[start_y, end_y],
                  scales=scales,
@@ -262,7 +254,7 @@ def line_mark(has_scales, start_x, start_y, end_x, end_y, color, label=None, lab
                  display_legend=label is not None,
                  labels_visibility=label_visibility or "label")
 
-def vertical_line_mark(has_scales, x, color, label=None, label_visibility=None):
+def vertical_line_mark(layer, x, color, label=None, label_visibility=None):
     """
     A specialization of `line_mark` specifically for vertical lines.
     Parameters
@@ -274,11 +266,8 @@ def vertical_line_mark(has_scales, x, color, label=None, label_visibility=None):
     color : str
         The desired color of the line, represented as a hex string.
     """
-    if isinstance(has_scales, LayerArtist):
-        viewer_state = has_scales.state.viewer_state
-    elif isinstance(has_scales, BqplotBaseView):
-        viewer_state = has_scales.state
-    return line_mark(has_scales, x, viewer_state.y_min, x, viewer_state.y_max, 
+    viewer_state = layer.state.viewer_state
+    return line_mark(layer, x, viewer_state.y_min, x, viewer_state.y_max, 
                      color, label=label, label_visibility=label_visibility)
 
 # Taken from https://jonlabelle.com/snippets/view/python/python-debounce-decorator-function

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -223,7 +223,7 @@ def fit_line(x, y):
     fitted_line = fit(line_init, x, y)
     return fitted_line
 
-def line_mark(has_scales, start_x, start_y, end_x, end_y, color, label=None):
+def line_mark(has_scales, start_x, start_y, end_x, end_y, color, label=None, label_visibility=None):
     """
     Creates a Lines mark between the given start and end points
     using the scales of the given layer.
@@ -255,14 +255,14 @@ def line_mark(has_scales, start_x, start_y, end_x, end_y, color, label=None):
     elif isinstance(has_scales, BqplotBaseView):
         scales = has_scales.scales
     return Lines(x=[start_x, end_x],
-                   y=[start_y, end_y],
-                   scales=scales,
-                   colors=[color],
-                   labels=[label] if label is not None else [],
-                   display_legend=label is not None,
-                   labels_visibility='label')
+                 y=[start_y, end_y],
+                 scales=scales,
+                 colors=[color],
+                 labels=[label] if label is not None else [],
+                 display_legend=label is not None,
+                 labels_visibility=label_visibility or "label")
 
-def vertical_line_mark(has_scales, x, color, label=None):
+def vertical_line_mark(has_scales, x, color, label=None, label_visibility=None):
     """
     A specialization of `line_mark` specifically for vertical lines.
     Parameters
@@ -278,7 +278,8 @@ def vertical_line_mark(has_scales, x, color, label=None):
         viewer_state = has_scales.state.viewer_state
     elif isinstance(has_scales, BqplotBaseView):
         viewer_state = has_scales.state
-    return line_mark(has_scales, x, viewer_state.y_min, x, viewer_state.y_max, color, label)
+    return line_mark(has_scales, x, viewer_state.y_min, x, viewer_state.y_max, 
+                     color, label=label, label_visibility=label_visibility)
 
 # Taken from https://jonlabelle.com/snippets/view/python/python-debounce-decorator-function
 def debounce(wait):

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -5,8 +5,9 @@ from math import log10
 from astropy.modeling import models, fitting
 from bqplot.marks import Lines
 from bqplot.scales import LinearScale
-from glue_jupyter.bqplot.histogram.layer_artist import BqplotHistogramLayerArtist
-from glue_jupyter.bqplot.scatter.layer_artist import BqplotScatterLayerArtist
+from glue_jupyter.bqplot.common import BqplotBaseView
+from glue_jupyter.bqplot.histogram import BqplotHistogramLayerArtist
+from glue_jupyter.bqplot.scatter import BqplotScatterLayerArtist
 from glue.core.state_objects import State
 import numpy as np
 from threading import Timer
@@ -221,7 +222,7 @@ def fit_line(x, y):
     fitted_line = fit(line_init, x, y)
     return fitted_line
 
-def line_mark(layer, start_x, start_y, end_x, end_y, color, label=None):
+def line_mark(has_scales, start_x, start_y, end_x, end_y, color, label=None):
     """
     Creates a Lines mark between the given start and end points
     using the scales of the given layer.
@@ -240,16 +241,18 @@ def line_mark(layer, start_x, start_y, end_x, end_y, color, label=None):
     color : str
         The desired color of the line, represented as a hex string.
     """
-    if isinstance(layer, BqplotScatterLayerArtist):
-        scales = layer.image.scales
-    elif isinstance(layer, BqplotHistogramLayerArtist):
-        layer_scales = layer.view.scales
+    if isinstance(has_scales, BqplotScatterLayerArtist):
+        scales = has_scales.image.scales
+    elif isinstance(has_scales, BqplotHistogramLayerArtist):
+        layer_scales = has_scales.view.scales
         layer_x = layer_scales['x']
         layer_y = layer_scales['y']
         scales = {
             'x': LinearScale(min=layer_x.min, max=layer_x.max, allow_padding=layer_x.allow_padding),
             'y': LinearScale(min=layer_y.min, max=layer_y.max, allow_padding=layer_y.allow_padding),
         }
+    elif isinstance(has_scales, BqplotBaseView):
+        scales = has_scales.scales
     return Lines(x=[start_x, end_x],
                    y=[start_y, end_y],
                    scales=scales,

--- a/cosmicds/viewers/dotplot/viewer.py
+++ b/cosmicds/viewers/dotplot/viewer.py
@@ -1,7 +1,6 @@
 from glue_jupyter.bqplot.histogram import BqplotHistogramView
 from .layer_artist import BqplotDotPlotLayerArtist
 from .state import DotPlotViewerState
-from ipywidgets import DOMWidget
 
 class BqplotDotPlotView(BqplotHistogramView):
 


### PR DESCRIPTION
This PR adds two components:

* One allows students to select a percentage (by default 50%, 68%, and 95%), and creates a subset that encompasses that percentage of the specified data/component around its median.
* The other allows students to select statistics (by default mean, median, and mode), and draws vertical lines on the given viewer at the locations of those statistics.

- [x] Update to handle multi-modal data