### PR TITLE
Fix issues with selectors

### DIFF
--- a/cosmicds/components/percentage_selector/percentage_selector.vue
+++ b/cosmicds/components/percentage_selector/percentage_selector.vue
@@ -23,6 +23,7 @@
                 icon
                 v-on="on"
                 v-bind="attrs"
+                @click="selected = option"
               >
                 <v-icon small>mdi-help</v-icon>
               </v-btn>

--- a/cosmicds/components/statistics_selector/statistics_selector.vue
+++ b/cosmicds/components/statistics_selector/statistics_selector.vue
@@ -23,6 +23,7 @@
                 icon
                 v-on="on"
                 v-bind="attrs"
+                @click="selected = stat"
               >
                 <v-icon small>mdi-help</v-icon>
               </v-btn>


### PR DESCRIPTION
This PR aims to resolve #246. Current changes include:
- When a student clicks the help (?) icon, the corresponding option is selected (for both selector types)
- Fix an issue where only one of the stat lines would be retained when selecting a percentage

This doesn't yet fix all of the pieces of #246, so I'm marking as a draft for now.