### PR TITLE
Add validation functionality to free responses

### DIFF
--- a/cosmicds/components/free_response.vue
+++ b/cosmicds/components/free_response.vue
@@ -36,7 +36,7 @@ module.exports = {
     },
     helpMessage: {
       type: String,
-      default: "Invalid format"
+      required: false
     },
     hint: {
       type: String,
@@ -68,6 +68,7 @@ module.exports = {
     return {
       response: "",
       initialized: false,
+      defaultHelpMessage: "Invalid format",
 
       allowedInput: {
         int: {
@@ -145,8 +146,9 @@ module.exports = {
         const pattern = new RegExp(`^[${allowed}]+$`);
 
         valid = pattern.test(input);
-        helpMessage = inputData.helpMessage;
+        helpMessage = this.helpMessage || inputData.helpMessage;
       }
+      helpMessage = helpMessage || this.defaultHelpMessage;
 
       if (this.rules.length > 0) {
         valid = this.rules.every(rule => rule(input));

--- a/cosmicds/components/free_response.vue
+++ b/cosmicds/components/free_response.vue
@@ -1,5 +1,6 @@
 <template>
   <v-textarea
+    ref="textarea"
     v-model="response"
     :outlined="outlined"
     :auto-grow="autoGrow"
@@ -7,6 +8,8 @@
     :color="color"
     :rows="rows"
     :hint="hint"
+    :icon="icon"
+    :rules="[isValid]"
     @blur="onBlur"
     v-intersect="dispatchInitializeEvent"
     class="cds-free-response"
@@ -31,20 +34,51 @@ module.exports = {
       type: String,
       default: "amber"
     },
+    help: {
+      type: String,
+      default: "Invalid format"
+    },
     hint: {
       type: String,
-      default: "Type your response here"
+      required: false
+    },
+    icon: {
+      type: String,
+      required: false
     },
     rows: {
       type: Number,
       default: 1
     },
-    tag: String
+    rules: {
+      type: Array, // Should be an array of functions with signature (string) => bool
+      default: []
+    },
+    tag: String,
+    type: {
+      type: String,
+      required: false
+    }
   },
   data: function () {
     return {
       response: "",
-      initialized: false
+      initialized: false,
+
+      allowedInput: {
+        int: {
+          characters: "-01233456789",
+          help: "Please input an integer"
+        },
+        uint: {
+          characters: "0123456789",
+          help: "Please input a non-negative integer"
+        },
+        float: {
+          characters: "-0123456789",
+          help: "Please input a number"
+        }
+      }
     };
   },
 
@@ -91,8 +125,24 @@ module.exports = {
       }
       this.initialized = true;
       document.removeEventListener("fr-initialize-response", this.onInitResponse);
+    },
+
+    isValid(input) {
+      if (this.type in this.allowedInput) {
+        const inputData = this.allowedInput[this.type];
+        const allowed = inputData.characters;
+        const pattern = new RegExp(`^[${allowed}]+$`);
+        return pattern.test(input) || inputData.help;
+      }
+
+      if (this.rules) {
+        return this.rules.every(rule => rule(input)) || this.help;
+      }
+
+      return true;
     }
   }
+
 };
 </script>
 

--- a/cosmicds/components/free_response.vue
+++ b/cosmicds/components/free_response.vue
@@ -34,7 +34,7 @@ module.exports = {
       type: String,
       default: "amber"
     },
-    help: {
+    helpMessage: {
       type: String,
       default: "Invalid format"
     },
@@ -49,6 +49,10 @@ module.exports = {
     rows: {
       type: Number,
       default: 1
+    },
+    allowEmpty: {
+      type: Boolean,
+      default: false
     },
     rules: {
       type: Array, // Should be an array of functions with signature (string) => bool
@@ -68,15 +72,15 @@ module.exports = {
       allowedInput: {
         int: {
           characters: "-01233456789",
-          help: "Please input an integer"
+          helpMessage: "Please input an integer"
         },
         uint: {
           characters: "0123456789",
-          help: "Please input a non-negative integer"
+          helpMessage: "Please input a non-negative integer"
         },
         float: {
-          characters: "-0123456789",
-          help: "Please input a number"
+          characters: "-0123456789.",
+          helpMessage: "Please input a number"
         }
       }
     };
@@ -128,18 +132,27 @@ module.exports = {
     },
 
     isValid(input) {
+      let valid = true;
+
+      if (!this.allowEmpty && !input) {
+        return "";
+      }
+
+      let helpMessage = this.helpMessage;
       if (this.type in this.allowedInput) {
         const inputData = this.allowedInput[this.type];
         const allowed = inputData.characters;
         const pattern = new RegExp(`^[${allowed}]+$`);
-        return pattern.test(input) || inputData.help;
+
+        valid = pattern.test(input);
+        helpMessage = inputData.helpMessage;
       }
 
-      if (this.rules) {
-        return this.rules.every(rule => rule(input)) || this.help;
+      if (this.rules.length > 0) {
+        valid = this.rules.every(rule => rule(input));
       }
 
-      return true;
+      return valid || helpMessage;
     }
   }
 

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -222,7 +222,7 @@ module.exports = {
     },
 
     allFreeResponsesFilled() {
-      return this.freeResponses.every(fr => fr.response.length > 0 && fr.$refs.textarea.valid);
+      return this.freeResponses.every(fr => fr.$refs.textarea.valid);
     },
 
     updateDisableNext() {

--- a/cosmicds/components/scaffold_alert.vue
+++ b/cosmicds/components/scaffold_alert.vue
@@ -222,7 +222,7 @@ module.exports = {
     },
 
     allFreeResponsesFilled() {
-      return this.freeResponses.every(fr => fr.response.length > 0);
+      return this.freeResponses.every(fr => fr.response.length > 0 && fr.$refs.textarea.valid);
     },
 
     updateDisableNext() {


### PR DESCRIPTION
This PR adds the ability to do input validation to the free response component. This comes in two forms:
- Preset "types" that define common use cases (integers, floats, unsigned (non-negative) integers)
- Custom validation rules

Specifying the `type` prop of a free response will activate the relevant rules. This includes a type-specific error message as well (if a custom one isn't specified). Additionally, one can specify custom validation via `rules`, as well as a specific `helpMessage`. If one uses both `type` and `rules`, the rules will be applied on top of the given type.

Also, while by default the free responses require a response (they can't be empty), an `allowEmpty` prop allows that to be modified, so that we can have optional free responses.