### PR TITLE
Fix issue with top margin on deployed app

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -715,7 +715,7 @@ textarea {
 .jp-Notebook-cell,
 .jp-mod-noInput,
 .jp-Cell-outputWrapper {
-  margin: 0;
+  margin: 0 !important;
   padding: 0;
 }
 


### PR DESCRIPTION
On the newly deployed app, we're seeing a small top margin of `5px` due to some Jupyter CSS overriding ours. This PR marks the relevant `margin` property as `!important` to work around this.