### PR TITLE
Updates to selector bounds

### DIFF
--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -1,5 +1,3 @@
-from math import ceil, floor
-
 from ipyvuetify import VuetifyTemplate
 from numpy import argsort, array
 from traitlets import Int, List, Unicode, observe

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -111,9 +111,22 @@ class PercentageSelector(VuetifyTemplate):
             layer = self.layers[index]
             layer.state.color = self._deselected_color
             bottom_index, top_index = percent_around_center_indices(data.size, selected)
+    
             sorted_indices = argsort(data)
             true_bottom = data[sorted_indices[bottom_index]]
             true_top = data[sorted_indices[top_index]]
+            expected_count = round(selected * data.size)
+            actual_count = top_index - bottom_index + 1
+            if expected_count != actual_count:
+                median = data.compute_statistic('median', viewer.state.x_att)
+                dist_bottom = abs(median - true_bottom)
+                dist_top = abs(median - true_top)
+                if dist_bottom > dist_top:
+                    bottom_index += 1
+                    true_bottom = data[sorted_indices[bottom_index]]
+                else:
+                    top_index -= 1
+                    true_top = data[sorted_indices[top_index]]
 
             # Ideally we could use something like a RangeSubsetState
             # but this can be problematic for our case when there are a small number

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -118,14 +118,25 @@ class PercentageSelector(VuetifyTemplate):
             expected_count = round(selected * data.size)
             actual_count = top_index - bottom_index + 1
             if expected_count != actual_count:
-                median = data.compute_statistic('median', viewer.state.x_att)
-                dist_bottom = abs(median - true_bottom)
-                dist_top = abs(median - true_top)
+                median = self.glue_data[index].compute_statistic('median', viewer.state.x_att)
+                if expected_count > actual_count:
+                    dist_bottom = abs(median - true_bottom)
+                    dist_top = abs(median - true_top)
+                    new_bottom_index = bottom_index + 1
+                    new_top_index = top_index - 1
+                else:
+                    new_bottom_index = max(0, bottom_index - 1)
+                    new_bottom = data[sorted_indices[new_bottom_index]]
+                    new_top_index = min(top_index + 1, data.size - 1)
+                    new_bottom = data[sorted_indices[new_top_index]]
+                    dist_bottom = abs(median - new_bottom)
+                    dist_top = abs(median - new_bottom)
+
                 if dist_bottom > dist_top:
-                    bottom_index += 1
+                    bottom_index = new_bottom_index
                     true_bottom = data[sorted_indices[bottom_index]]
                 else:
-                    top_index -= 1
+                    top_index = new_top_index
                     true_top = data[sorted_indices[top_index]]
 
             # Ideally we could use something like a RangeSubsetState

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -76,6 +76,21 @@ class PercentageSelector(VuetifyTemplate):
         index = next((idx for idx, x in enumerate(bins) if x >= value), 0)
         return bins[index - 1], bins[index]
 
+    def _rounded_bound(self, bound):
+        if self.resolution is None:
+            return bound
+        return round(bound, self.resolution)
+
+    def _bin_rounded_bound(self, bound, bins):
+        rounded_bound = self._rounded_bound(bound)
+        resolution = 10 ** (-self.resolution)
+        rounded_bin_bounds = self._bin_bounds(bound, bins)
+        if bound < rounded_bin_bounds[0]:
+            rounded_bound -= resolution
+        elif bound > rounded_bin_bounds[1]:
+            rounded_bound += resolution
+        return rounded_bound
+
     @observe('selected')
     def _update(self, change):
         if change["old"] is None:
@@ -120,26 +135,8 @@ class PercentageSelector(VuetifyTemplate):
             indices = [si for i, si in enumerate(sorted_indices) if i >= bottom_index and i <= top_index]
             state = ElementSubsetState(indices=indices)
             states.append(state)
-            if self.resolution is not None:
-                rounded_bottom = round(true_bottom, self.resolution)
-                rounded_top = round(true_top, self.resolution)
-            else:
-                rounded_bottom = true_bottom
-                rounded_top = true_top
-
-            if bins is not None:
-                resolution = 10 ** (-self.resolution)
-                bins_rounded_bottom = self._bin_bounds(rounded_bottom, bins)
-                if true_bottom < bins_rounded_bottom[0]:
-                    rounded_bottom -= resolution
-                elif true_bottom > bins_rounded_bottom[1]:
-                    rounded_bottom += resolution 
-
-                bins_rounded_top = self._bin_bounds(rounded_top, bins)
-                if true_top < bins_rounded_top[0]:
-                    rounded_top -= resolution
-                elif true_top > bins_rounded_top[1]:
-                    rounded_top += resolution
+            rounded_bottom = self._bin_rounded_bound(true_bottom, bins)
+            rounded_top = self._bin_rounded_bound(true_top, bins)
 
             bottom_str = "{:g}".format(rounded_bottom)
             top_str = "{:g}".format(rounded_top)

--- a/cosmicds/components/percentage_selector/percentage_selector.py
+++ b/cosmicds/components/percentage_selector/percentage_selector.py
@@ -115,15 +115,22 @@ class PercentageSelector(VuetifyTemplate):
             sorted_indices = argsort(data)
             true_bottom = data[sorted_indices[bottom_index]]
             true_top = data[sorted_indices[top_index]]
-            expected_count = round(selected * data.size)
+            expected_count = round(selected * data.size / 100)
             actual_count = top_index - bottom_index + 1
             if expected_count != actual_count:
                 median = self.glue_data[index].compute_statistic('median', viewer.state.x_att)
-                if expected_count > actual_count:
+                if expected_count < actual_count:
                     dist_bottom = abs(median - true_bottom)
                     dist_top = abs(median - true_top)
                     new_bottom_index = bottom_index + 1
                     new_top_index = top_index - 1
+
+                    if dist_bottom > dist_top:
+                        bottom_index = new_bottom_index
+                        true_bottom = data[sorted_indices[bottom_index]]
+                    else:
+                        top_index = new_top_index
+                        true_top = data[sorted_indices[top_index]]
                 else:
                     new_bottom_index = max(0, bottom_index - 1)
                     new_bottom = data[sorted_indices[new_bottom_index]]
@@ -132,12 +139,12 @@ class PercentageSelector(VuetifyTemplate):
                     dist_bottom = abs(median - new_bottom)
                     dist_top = abs(median - new_bottom)
 
-                if dist_bottom > dist_top:
-                    bottom_index = new_bottom_index
-                    true_bottom = data[sorted_indices[bottom_index]]
-                else:
-                    top_index = new_top_index
-                    true_top = data[sorted_indices[top_index]]
+                    if dist_bottom < dist_top or new_top_index == data.size - 1:
+                        bottom_index = new_bottom_index
+                        true_bottom = data[sorted_indices[bottom_index]]
+                    else:
+                        top_index = new_top_index
+                        true_top = data[sorted_indices[top_index]]
 
             # Ideally we could use something like a RangeSubsetState
             # but this can be problematic for our case when there are a small number

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -1,9 +1,7 @@
-from collections import Counter
 from ipyvuetify import VuetifyTemplate
-from numpy import amax, flatnonzero, histogram
 from traitlets import Dict, List, Unicode, observe
 
-from ...utils import load_template, vertical_line_mark
+from ...utils import load_template, mode, vertical_line_mark
 
 class StatisticsSelector(VuetifyTemplate):
 
@@ -40,24 +38,12 @@ class StatisticsSelector(VuetifyTemplate):
         for viewer in self.viewers:
             viewer.figure.observe(self._on_marks_updated, names=["marks"])
 
-    def _mode(self, viewer, data, bins):
-        component_id = viewer.state.x_att
-        values = data[component_id]
-        if bins is not None:
-            hist, hbins = histogram(values, bins=bins)
-            indices = flatnonzero(hist == amax(hist)) 
-            return [0.5 * (hbins[idx] + hbins[idx + 1]) for idx in indices]
-        else:
-            counter = Counter(data)
-            max_count = counter.most_common(1)[0][1]
-            return [k for k, v in counter.items() if v == max_count]
-
     # glue doesn't implement a mode statistic, so we roll our own
     # Since there can be multiple modes, mode can be a list
     # and so we return a list for every statistic to make things simpler
     def _find_statistic(self, stat, viewer, data, bins):
         if stat == 'mode':
-            return self._mode(viewer, data, bins)
+            return mode(viewer, data, bins)
         else:
             return [data.compute_statistic(stat, viewer.state.x_att)]
 

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -43,7 +43,7 @@ class StatisticsSelector(VuetifyTemplate):
     # and so we return a list for every statistic to make things simpler
     def _find_statistic(self, stat, viewer, data, bins):
         if stat == 'mode':
-            return mode(viewer, data, bins)
+            return mode(data, viewer.state.x_att, bins)
         else:
             return [data.compute_statistic(stat, viewer.state.x_att)]
 

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -309,7 +309,7 @@ def frexp10(x, normed=False):
     return mantissa, exp
 
 def percentile_index(size, percent, method=round):
-    return min(method(size * percent / 100), size - 1)
+    return min(method((size - 1) * percent / 100), size - 1)
 
 def percent_around_center_indices(size, percent):
     """

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -320,8 +320,8 @@ def percent_around_center_indices(size, percent):
     bottom_percent = 50 - around_median
     top_percent = 50 + around_median
 
-    bottom_index = percentile_index(size, bottom_percent, method=ceil)
-    top_index = percentile_index(size, top_percent, method=floor)
+    bottom_index = percentile_index(size, bottom_percent)
+    top_index = percentile_index(size, top_percent)
     return bottom_index, top_index
 
 def mode(data, component_id, bins=None):

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import json
 import os
 from math import ceil, floor, log10
@@ -322,3 +323,21 @@ def percent_around_center_indices(size, percent):
     bottom_index = percentile_index(size, bottom_percent, method=ceil)
     top_index = percentile_index(size, top_percent, method=floor)
     return bottom_index, top_index
+
+def mode(data, component_id, bins=None):
+    """
+    Compute the mode of a given dataset, using the component corresponding
+    to the given ID. If bins are given, the data values will be binned
+    before finding the modes. Bins should be specified as an integer (# bins)
+    or sequence of scalars.
+    """
+
+    values = data[component_id]
+    if bins is not None:
+        hist, hbins = np.histogram(values, bins=bins)
+        indices = np.flatnonzero(hist == np.amax(hist))
+        return [0.5 * (hbins[idx] + hbins[idx + 1]) for idx in indices]
+    else:
+        counter = Counter(data)
+        max_count = counter.most_common(1)[0][1]
+        return [k for k, v in counter.items() if v == max_count]

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -1,12 +1,9 @@
 import json
 import os
-from math import log10
+from math import ceil, floor, log10
 
 from astropy.modeling import models, fitting
 from bqplot.marks import Lines
-from bqplot.scales import LinearScale
-from glue.viewers.common.viewer import LayerArtist
-from glue_jupyter.bqplot.common import BqplotBaseView
 from glue_jupyter.bqplot.histogram import BqplotHistogramLayerArtist
 from glue_jupyter.bqplot.scatter import BqplotScatterLayerArtist
 from glue.core.state_objects import State
@@ -309,3 +306,19 @@ def frexp10(x, normed=False):
     exp = int(log10(x)) + int(normed)
     mantissa = x / (10 ** exp)
     return mantissa, exp
+
+def percentile_index(size, percent, method=round):
+    return min(method(size * percent / 100), size - 1)
+
+def percent_around_center_indices(size, percent):
+    """
+    Compute the indices of the given percent around the center.
+    """
+
+    around_median = percent / 2
+    bottom_percent = 50 - around_median
+    top_percent = 50 + around_median
+
+    bottom_index = percentile_index(size, bottom_percent, method=ceil)
+    top_index = percentile_index(size, top_percent, method=floor)
+    return bottom_index, top_index


### PR DESCRIPTION
This PR attempts to address the issues with the bounds from regions selected using the percentage selector (see the second item in https://github.com/cosmicds/cosmicds/issues/246#issuecomment-1640330084). The logic for the selector now takes into account how many items there should be in the percentage range, and makes sure that this is the case by either dropping the edge value further from the mean, or adding the new one closer to the mean, as necessary.

Also, some of the generic logic has been refactored out into utility functions so that it can be used in other places (e.g. calculating the relevant statistics for the student's particular class data in the Hubble story).