### PR TITLE
Use API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ MANIFEST
 .ipynb_checkpoints
 notebooks/*.fits
 
+# Environment variable definitions
+.env
+
 # Sphinx
 docs/api
 docs/_build

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -140,7 +140,7 @@ class Stage(TemplateMixin):
         self.story_state = story_state
         self.app_state = app_state
         self.index = index
-        self.request_session = request_session()
+        self._request_session = request_session()
 
         self.stage_state = kwargs.get('stage_state', self._state_cls())
 

--- a/cosmicds/phases.py
+++ b/cosmicds/phases.py
@@ -5,7 +5,7 @@ from cosmicds.components.viewer_layout import ViewerLayout
 from cosmicds.events import WriteToDatabaseMessage
 
 from cosmicds.mixins import TemplateMixin, HubMixin
-from cosmicds.utils import debounce
+from cosmicds.utils import debounce, request_session
 from glue.core import Data
 from glue.core.state_objects import State
 from echo import DictCallbackProperty, CallbackProperty, add_callback
@@ -53,6 +53,7 @@ class Story(CDSState, HubMixin):
         super().__init__(*args, **kwargs)
 
         self._session = session
+        self._request_session = request_session()
         self.viewers = {}
 
         # When the step index or completion status changes, store that change
@@ -139,6 +140,7 @@ class Stage(TemplateMixin):
         self.story_state = story_state
         self.app_state = app_state
         self.index = index
+        self.request_session = request_session()
 
         self.stage_state = kwargs.get('stage_state', self._state_cls())
 

--- a/cosmicds/registries.py
+++ b/cosmicds/registries.py
@@ -3,7 +3,7 @@ from ipyvuetify import VuetifyTemplate
 from glue.core.state_objects import State
 import requests
 
-from cosmicds.utils import API_URL
+from cosmicds.utils import API_URL, request_session
 
 __all__ = ['stage_registry']
 
@@ -60,7 +60,8 @@ class StoryRegistry(UniqueDictRegistry):
         story_state = story_entry['cls'](session)
         story_state.name = name
 
-        response = requests.get(f"{API_URL}/story-state/{app_state.student['id']}/{name}")
+        # This should only get run once per story - using a one-off session is fine for now
+        response = request_session().get(f"{API_URL}/story-state/{app_state.student['id']}/{name}")
         data = response.json()
         state = data["state"]
 

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -353,6 +353,11 @@ def mode(data, component_id, bins=None):
 
 
 def request_session():
+    """
+    Returns a `requests.Session` object that has the relevant authorization parameters
+    to interface with the CosmicDS API server (provided that environment variables
+    are set correctly).
+    """
     session = Session()
     session.headers.update({"Authorization": os.getenv("CDS_API_KEY")})
     return session

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -2,6 +2,7 @@ from collections import Counter
 import json
 import os
 from math import ceil, floor, log10
+from requests import Session
 
 from astropy.modeling import models, fitting
 from bqplot.marks import Lines
@@ -215,11 +216,13 @@ def convert_material_color(color_string):
         result = result[part]
     return result
 
+
 def fit_line(x, y):
     fit = fitting.LinearLSQFitter()
     line_init = models.Linear1D(intercept=0, fixed={'intercept':True})
     fitted_line = fit(line_init, x, y)
     return fitted_line
+
 
 def line_mark(layer, start_x, start_y, end_x, end_y, color, label=None, label_visibility=None):
     """
@@ -252,6 +255,7 @@ def line_mark(layer, start_x, start_y, end_x, end_y, color, label=None, label_vi
                  display_legend=label is not None,
                  labels_visibility=label_visibility or "label")
 
+
 def vertical_line_mark(layer, x, color, label=None, label_visibility=None):
     """
     A specialization of `line_mark` specifically for vertical lines.
@@ -267,6 +271,7 @@ def vertical_line_mark(layer, x, color, label=None, label_visibility=None):
     viewer_state = layer.state.viewer_state
     return line_mark(layer, x, viewer_state.y_min, x, viewer_state.y_max, 
                      color, label=label, label_visibility=label_visibility)
+
 
 # Taken from https://jonlabelle.com/snippets/view/python/python-debounce-decorator-function
 def debounce(wait):
@@ -293,6 +298,7 @@ def debounce(wait):
 
     return decorator
 
+
 def frexp10(x, normed=False):
     """
     Find the mantissa and exponent of a value in base 10.
@@ -308,8 +314,10 @@ def frexp10(x, normed=False):
     mantissa = x / (10 ** exp)
     return mantissa, exp
 
+
 def percentile_index(size, percent, method=round):
     return min(method((size - 1) * percent / 100), size - 1)
+
 
 def percent_around_center_indices(size, percent):
     """
@@ -323,6 +331,7 @@ def percent_around_center_indices(size, percent):
     bottom_index = percentile_index(size, bottom_percent)
     top_index = percentile_index(size, top_percent)
     return bottom_index, top_index
+
 
 def mode(data, component_id, bins=None):
     """
@@ -341,3 +350,9 @@ def mode(data, component_id, bins=None):
         counter = Counter(data)
         max_count = counter.most_common(1)[0][1]
         return [k for k, v in counter.items() if v == max_count]
+
+
+def request_session():
+    session = Session()
+    session.headers.update({"Authorization": os.getenv("CDS_API_KEY")})
+    return session


### PR DESCRIPTION
This PR updates our main classes - `Application`, `Story`, and `Stage` - to use a `requests.Session` object with an API key (obtained from an environment variable) to make things compatible with the changes in https://github.com/cosmicds/cds-api/pull/81.

In order to avoid prop drilling-style problems (in Hubble, some of the components need to make update requests), this PR provides this session via a utility function. Currently the only thing that's necessary for this session is the API key being in the header, so it's fine if each stage/component has its own session. If in the future we end up needing to preserve things like cookies across the entire app, we could change this to be a singleton-style function (i.e. return the same instance from each call).