### PR TITLE
Calculate MC score based on wrong attempts rather than tries

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -212,7 +212,8 @@ class Application(VuetifyTemplate, HubListener):
         self.story_state.mc_scoring[key][args["tag"]] = {
             "score": args["score"],
             "choice": args["choice"],
-            "tries": args["tries"]
+            "tries": args["tries"],
+            "wrong_attempts": args["wrong_attempts"]
         }
 
     def vue_update_free_response(self, args):

--- a/cosmicds/components/mc_radiogroup.vue
+++ b/cosmicds/components/mc_radiogroup.vue
@@ -130,7 +130,7 @@ module.exports = {
       }
       this.complete = correct || (this.correctAnswers.length === 0 && neutral);
       if (this.scoring && this.complete) {
-        this.score = correct ? this.getScore(this.wrongAttempts) : 0;
+        this.score = this.getScore(this.wrongAttempts);
       }
       if (this.scoreTag !== undefined && !forInitialization) {
         document.dispatchEvent(


### PR DESCRIPTION
This PR looks to resolve #263. To do this, the multiple choice component now tracks the number of wrong attempts in addition to the number of tries. Scoring is now done based on the number of wrong attempts, meaning that neutral attempts don't impact the score.