### PR TITLE
Bump required glue-jupyter version

### DIFF
--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -243,9 +243,7 @@ def line_mark(layer, start_x, start_y, end_x, end_y, color, label=None, label_vi
     color : str
         The desired color of the line, represented as a hex string.
     """
-    if isinstance(layer, BqplotScatterLayerArtist):
-        scales = layer.image.scales
-    elif isinstance(layer, BqplotHistogramLayerArtist):
+    if isinstance(layer, (BqplotHistogramLayerArtist, BqplotScatterLayerArtist)):
         scales = layer.view.scales
     return Lines(x=[start_x, end_x],
                  y=[start_y, end_y],

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
   numpy
   ipywidgets < 8
   glue-core >= 1.6
-  glue-jupyter >= 0.12
+  glue-jupyter >= 0.19
   pywwt @ git+https://github.com/Carifio24/pywwt@prekdr
   astropy
   traitlets


### PR DESCRIPTION
Since we're updating Hubble to account for upstream `glue-jupyter` updates, we should bump the package version here.