### PR TITLE
Use glue's `compute_histogram` for mode calculation

### DIFF
--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -43,7 +43,7 @@ class StatisticsSelector(VuetifyTemplate):
     # and so we return a list for every statistic to make things simpler
     def _find_statistic(self, stat, viewer, data, bins):
         if stat == 'mode':
-            return mode(data, viewer.state.x_att, bins)
+            return mode(data, viewer.state.x_att, bins=bins, range=[viewer.state.x_min, viewer.state.x_max])
         else:
             return [data.compute_statistic(stat, viewer.state.x_att)]
 

--- a/cosmicds/components/statistics_selector/statistics_selector.py
+++ b/cosmicds/components/statistics_selector/statistics_selector.py
@@ -43,7 +43,7 @@ class StatisticsSelector(VuetifyTemplate):
     # and so we return a list for every statistic to make things simpler
     def _find_statistic(self, stat, viewer, data, bins):
         if stat == 'mode':
-            return mode(data, viewer.state.x_att, bins=bins, range=[viewer.state.x_min, viewer.state.x_max])
+            return mode(data, viewer.state.x_att, bins=bins, range=[viewer.state.hist_x_min, viewer.state.hist_x_max])
         else:
             return [data.compute_statistic(stat, viewer.state.x_att)]
 

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -331,7 +331,7 @@ def percent_around_center_indices(size, percent):
     return bottom_index, top_index
 
 
-def mode(data, component_id, bins=None):
+def mode(data, component_id, bins=None, range=None):
     """
     Compute the mode of a given dataset, using the component corresponding
     to the given ID. If bins are given, the data values will be binned
@@ -339,13 +339,13 @@ def mode(data, component_id, bins=None):
     or sequence of scalars.
     """
 
-    values = data[component_id]
     if bins is not None:
-        hist, hbins = np.histogram(values, bins=bins)
+        hist = data.compute_histogram([component_id], range=[range], bins=[len(bins)-1])
         indices = np.flatnonzero(hist == np.amax(hist))
-        return [0.5 * (hbins[idx] + hbins[idx + 1]) for idx in indices]
+        return [0.5 * (bins[idx] + bins[idx + 1]) for idx in indices]
     else:
-        counter = Counter(data)
+        values = data[component_id]
+        counter = Counter(values)
         max_count = counter.most_common(1)[0][1]
         return [k for k, v in counter.items() if v == max_count]
 


### PR DESCRIPTION
The binned form of our mode calculation essentially just makes a histogram and returns the values that correspond to the tallest bar(s). This PR changes this calculation to use the `compute_histogram` method of a glue `Data` object to compute this histogram, rather than numpy, for consistency with the glue histogram viewer.