### PR TITLE
Only contain the layout in the notebook

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -790,8 +790,8 @@ mjx-assistive-mml cds-input {
   margin: 2px;
 }
 
-#inspire{
-  contain:layout;
+#notebook-container div#inspire {
+  contain: layout;
 }
 
 /* This is not responding to window size, so just leave off for now.


### PR DESCRIPTION
This fixes an issue first noted on 

https://github.com/cosmicds/hubbleds/issues/322

where the menu was reachable on small screens. This is a side-effect of a small suggestion I had made to contain the layout. This PR simply restricts the the CSS to only affect users running this in a notebootk.