### PR TITLE
add extra helper text to free response validation error messages

### DIFF
--- a/cosmicds/components/free_response.vue
+++ b/cosmicds/components/free_response.vue
@@ -73,15 +73,15 @@ module.exports = {
       allowedInput: {
         int: {
           characters: "-01233456789",
-          helpMessage: "Please input an integer"
+          helpMessage: "Please input an integer. (Be sure there are no spaces.)"
         },
         uint: {
           characters: "0123456789",
-          helpMessage: "Please input a non-negative integer"
+          helpMessage: "Please input a non-negative integer. (Be sure there are no spaces.)"
         },
         float: {
           characters: "-0123456789.",
-          helpMessage: "Please input a number"
+          helpMessage: "Please input a number. (Be sure there are no spaces.)"
         }
       }
     };


### PR DESCRIPTION
I made a few entries while testing that were numbers that wouldn't validate, and I realized I accidentally put extra spaces in the boxes, so I propose adding this extra bit of text to help students out, in case they do what I did. I thought about adding " " to the list of accepted characters, but that would allow students to press the space bar without entering anything and then move on.

<img width="1086" alt="Screen Shot 2023-11-09 at 12 45 17 AM" src="https://github.com/cosmicds/cosmicds/assets/12750048/d3093220-66b0-4081-9447-0eda57a52c3f">


