### PR TITLE
Add request logging

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -63,7 +63,7 @@ class Application(VuetifyTemplate, HubListener):
         self.request_session = self.add_logging(request_session())
         
         # comment to display the UI message in the console
-        self.observe(lambda change: log_to_console(change['new'], css="color:pink;"), 'loading_status_message')
+        # self.observe(lambda change: log_to_console(change['new'], css="color:pink;"), 'loading_status_message')
 
         # NOTE: This procedure is only valid when using ContainDS
         if "JUPYTERHUB_USER" in os.environ:

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -7,7 +7,8 @@
       indeterminate
       color="primary"
       ></v-progress-circular>
-      Loading User Data...
+      <p>Loading User Data...</p>
+      <p> {{ loading_status_message }} </p>
     </v-overlay>
     <v-app-bar
       app

--- a/cosmicds/registries.py
+++ b/cosmicds/registries.py
@@ -3,7 +3,7 @@ from ipyvuetify import VuetifyTemplate
 from glue.core.state_objects import State
 import requests
 
-from cosmicds.utils import API_URL, request_session
+from cosmicds.utils import API_URL, request_session, log_to_console
 
 __all__ = ['stage_registry']
 
@@ -74,6 +74,7 @@ class StoryRegistry(UniqueDictRegistry):
         for k, v in sorted(story_entry['stages'].items()):
             stage_cls = v['cls']
             stage_state = stage_cls._state_cls()
+            log_to_console(f"Setting up stage {k}")
             if state is not None and k in state["stages"] and "state" in state["stages"][k]:
                 stage_state.update_from_dict(state["stages"][k]["state"])
             stage = stage_cls(session, story_state, app_state, index=k, stage_state=stage_state)


### PR DESCRIPTION
This PR adds logging of API requests from the python side by adding a [transport adapter](https://requests.readthedocs.io/en/latest/user/advanced.html?#transport-adapters) to the session that is created. 

It also logs the loading of the stages in `registries.py`

It updates the loading screen text for major steps in the `app.py` `_setup` script. The logs from the cosmicds app are labeled `Main App`. The hubbleds app creates two other sessions. 

The transport adapter has a random 3 digit identifier generated when it is created so that unique sessions can be easily identified

<img width="646" alt="image" src="https://github.com/cosmicds/cosmicds/assets/7862929/88746ce6-addf-488e-8ddd-a9565c9ed1ad">
