### PR TITLE
Styling updates

### DIFF
--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -6,9 +6,9 @@ from reacton import ipyvuetify as rv
 
 import datetime
 from solara_enterprise import auth
+from solara.lab import theme as theme
 
 from .components import MathJaxSupport
-
 
 @solara.component
 def Layout(children=[]):
@@ -31,8 +31,7 @@ def Layout(children=[]):
             with rv.Btn(icon=True):
                 rv.Icon(children=["mdi-tune-vertical"])
 
-            with rv.Btn(icon=True):
-                rv.Icon(children=["mdi-brightness-4"])
+            solara.lab.ThemeToggle(on_icon ="mdi-brightness-4", off_icon ="mdi-brightness-4", enable_auto = False)
 
             with rv.Chip(class_="ma-2"):
                 with rv.Avatar(left=True, class_="darken-4"):

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -75,26 +75,39 @@ def Layout(children=[]):
                 )
 
         with rv.Footer(
-            class_="text-center",
+            class_="text-center align-items",
             padless=True,
             app=True,
             inset=True,
         ):
-            with rv.Card(flat=True, tile=True, style_="width: 100%"):
+            with rv.Card(flat=True, tile=True, class_="cosmicds-footer", style_="width: 100%;"):
                 rv.Divider()
 
-                with rv.CardText():
-                    solara.HTML(
-                        tag="span",
-                        unsafe_innerHTML=rf"""
-                    The material contained on this website is based upon 
-                    work supported by NASA under award No. 80NSSC21M0002. 
-                    Any opinions, findings, and conclusions or 
-                    recommendations expressed in this material are those of 
-                    the author(s) and do not necessarily reflect the views 
-                    of the National Aeronautics and Space Administration.
-                    <br />{datetime.date.today().year} - <strong>CosmicDS</strong>
-                    """,
-                    )
+                with solara.Columns([2,10]):
+                    with solara.Column(classes=["cosmicds-footer"]):
+                        with rv.CardText():
+                            solara.HTML(
+                                unsafe_innerHTML=
+                                rf"""
+                                {datetime.date.today().year} - <b>CosmicDS</b>
+                                """,
+                                style="font-size: 18px;"
+                            )
+
+                    with solara.Column(classes=["cosmicds-footer"]):
+                        with rv.CardText():
+                            solara.HTML(
+                                tag="span",
+                                unsafe_innerHTML=
+                            """
+                            The material contained on this website is based upon 
+                            work supported by NASA under award No. 80NSSC21M0002. 
+                            Any opinions, findings, and conclusions or 
+                            recommendations expressed in this material are those of 
+                            the author(s) and do not necessarily reflect the views 
+                            of the National Aeronautics and Space Administration.
+                            """,
+                                style="font-size: 12px; line-height: 12px",
+                            )
 
     return main


### PR DESCRIPTION
This is a small PR that wires up the theme toggle button and updates the footer styling. (Note that the css classes for this are in https://github.com/cosmicds/hubbleds/pull/357. They were ignored when I put them in this repo.)

I'm having a problem with the theming where the `v-sheet` component in the slideshow carousel has a `theme--dark` class applied to it when I'm in light mode. That is the only component that has the incorrect theming applied, and I can't figure out if we have a rogue `dark` designation somewhere, or what is causing this. If anyone can help track this down, I'd be grateful!

<img width="1030" alt="Screenshot 2024-05-03 at 6 54 25 PM" src="https://github.com/cosmicds/cosmicds/assets/12750048/383fca51-6556-45f3-b3bc-febf2aba6e44">
