### PR TITLE
Add decorator to encapsulate tool registration

### DIFF
--- a/src/cosmicds/config.py
+++ b/src/cosmicds/config.py
@@ -1,0 +1,14 @@
+from glue.config import viewer_tool
+
+
+class RegisterTool():
+
+    def __call__(self, tool_cls):
+        try:
+            viewer_tool(tool_cls)
+        except ValueError:
+            print(f"Tool ID {tool_cls.tool_id} already registered")
+        return tool_cls
+
+
+register_tool = RegisterTool()

--- a/src/cosmicds/tools/__init__.py
+++ b/src/cosmicds/tools/__init__.py
@@ -1,1 +1,15 @@
-from .line_fit_tool import LineFitTool
+from glue.config import viewer_tool
+
+from .line_fit_tool import LineFitTool  # noqa
+
+
+class RegisterTool():
+
+    def __call__(self, tool_cls):
+        try:
+            viewer_tool(tool_cls)
+        except ValueError:
+            print(f"Tool ID {tool_cls.tool_id} already registered")
+
+
+register_tool = RegisterTool()

--- a/src/cosmicds/tools/__init__.py
+++ b/src/cosmicds/tools/__init__.py
@@ -1,15 +1,1 @@
-from glue.config import viewer_tool
-
 from .line_fit_tool import LineFitTool  # noqa
-
-
-class RegisterTool():
-
-    def __call__(self, tool_cls):
-        try:
-            viewer_tool(tool_cls)
-        except ValueError:
-            print(f"Tool ID {tool_cls.tool_id} already registered")
-
-
-register_tool = RegisterTool()

--- a/src/cosmicds/tools/line_fit_tool.py
+++ b/src/cosmicds/tools/line_fit_tool.py
@@ -11,11 +11,12 @@ from numpy import isnan
 from numpy.linalg import LinAlgError
 from traitlets import Unicode, HasTraits
 
+from . import register_tool
 from cosmicds.utils import fit_line, line_mark
 
 
 
-@viewer_tool
+@register_tool
 class LineFitTool(Tool, HubListener, HasTraits):
 
     tool_id = 'cds:linefit'

--- a/src/cosmicds/tools/line_fit_tool.py
+++ b/src/cosmicds/tools/line_fit_tool.py
@@ -11,7 +11,7 @@ from numpy import isnan
 from numpy.linalg import LinAlgError
 from traitlets import Unicode, HasTraits
 
-from . import register_tool
+from cosmicds.config import register_tool
 from cosmicds.utils import fit_line, line_mark
 
 


### PR DESCRIPTION
This PR creates a `register_tool` decorator that encapsulates what @nmearl used in https://github.com/cosmicds/hubbleds/pull/369 to allow us to easily reuse this across tools and stories. It also updates the tools in this package to use this decorator.