### PR TITLE
Update package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,13 @@
+include README.md
+include CHANGELOG.rst
+include setup.cfg
+include LICENSE.txt
+
+recursive-include src *.pyx *.c *.vue *.csv *.ipynb
+recursive-include docs *
+
+prune build
+prune docs/_build
+prune docs/api
+
+global-exclude *.pyc *.o

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,9 @@ testing =
     pytest
     pytest-cov
 
+[options.package_data]
+* = *.vue
+
 [options.entry_points]
 # Add here console scripts like:
 # console_scripts =


### PR DESCRIPTION
While working on the environment setup, I realized that we currently don't have things like the `.vue` files listed in the package data, which is a problem. This PR looks to fix that.

The new manifest file here is based on the one we had on the legacy branch, with a few references to folders that don't exist anymore trimmed out.