### PR TITLE
Add Plotly support component

### DIFF
--- a/src/cosmicds/components/__init__.py
+++ b/src/cosmicds/components/__init__.py
@@ -1,5 +1,6 @@
 from .scaffold_alert import ScaffoldAlert
 from .math_jax_support.math_jax_support import MathJaxSupport
+from .plotly_support.plotly_support import PlotlySupport
 from .viewer_layout import *
 from .debug_control import StateEditor
 from .layer_toggle import LayerToggle

--- a/src/cosmicds/components/plotly_support/PlotlySupport.vue
+++ b/src/cosmicds/components/plotly_support/PlotlySupport.vue
@@ -1,0 +1,15 @@
+<script>
+export default {
+  async mounted() {
+
+    // For RequireJS reasons we can't do the script tag approach that we use for e.g. MathJax
+    // Doing that with Plotly gives this error: https://requirejs.org/docs/errors.html#mismatch
+    require(["https://cdn.plot.ly/plotly-2.32.0.min.js"], function(plotly) {
+      window.Plotly = plotly;
+    });
+  }
+}
+</script>
+
+<template>
+</template>

--- a/src/cosmicds/components/plotly_support/PlotlySupport.vue
+++ b/src/cosmicds/components/plotly_support/PlotlySupport.vue
@@ -1,11 +1,18 @@
 <script>
 export default {
-  async mounted() {
+  mounted() {
 
-    // For RequireJS reasons we can't do the script tag approach that we use for e.g. MathJax
-    // Doing that with Plotly gives this error: https://requirejs.org/docs/errors.html#mismatch
-    require(["https://cdn.plot.ly/plotly-2.32.0.min.js"], function(plotly) {
-      window.Plotly = plotly;
+    window.plotlyPromise = new Promise((resolve, reject) => {
+      // For RequireJS reasons we can't do the script tag approach that we use for e.g. MathJax
+      // Doing that with Plotly gives this error: https://requirejs.org/docs/errors.html#mismatch
+      require(["https://cdn.plot.ly/plotly-2.32.0.min.js"], function(plotly) {
+        window.Plotly = plotly;
+        resolve();
+      },
+      function(error) {
+        reject();
+      });
+
     });
   }
 }

--- a/src/cosmicds/components/plotly_support/plotly_support.py
+++ b/src/cosmicds/components/plotly_support/plotly_support.py
@@ -1,0 +1,5 @@
+import solara
+
+@solara.component_vue("PlotlySupport.vue")
+def PlotlySupport():
+    pass

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -8,7 +8,7 @@ import datetime
 from solara_enterprise import auth
 from solara.lab import theme as theme
 
-from .components import MathJaxSupport
+from .components import MathJaxSupport, PlotlySupport
 
 @solara.component
 def Layout(children=[]):
@@ -22,6 +22,7 @@ def Layout(children=[]):
 
         # Mount external javascript libraries
         MathJaxSupport()
+        PlotlySupport()
 
         with rv.AppBar(elevate_on_scroll=False, app=True, flat=True):
             rv.ToolbarTitle(children=["CosmicDS"])


### PR DESCRIPTION
This PR adds a component for allowing us to use Plotly on the JS-side, similar to what we currently have for MathJax. The only real difference in the setup is that due to something in the way the Plotly code is structured, using a script tag gave me [this RequireJS error](https://requirejs.org/docs/errors.html#mismatch), and so this PR calls on RequireJS directly to import Plotly.