### PR TITLE
Add statistics and percentage selector components

### DIFF
--- a/src/cosmicds/components/__init__.py
+++ b/src/cosmicds/components/__init__.py
@@ -4,3 +4,4 @@ from .plotly_support.plotly_support import PlotlySupport
 from .viewer_layout import *
 from .debug_control import StateEditor
 from .layer_toggle import LayerToggle
+from .statistics_selector import StatisticsSelector

--- a/src/cosmicds/components/__init__.py
+++ b/src/cosmicds/components/__init__.py
@@ -5,3 +5,4 @@ from .viewer_layout import *
 from .debug_control import StateEditor
 from .layer_toggle import LayerToggle
 from .statistics_selector import StatisticsSelector
+from .percentage_selector import PercentageSelector

--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -1,4 +1,9 @@
+from numpy import argsort, array
 import solara
+
+from glue.core.subset import ElementSubsetState
+
+from ..utils import percent_around_center_indices
 
 
 @solara.component
@@ -12,6 +17,7 @@ def PercentageSelector(viewers, glue_data, bins=None, **kwargs):
     subset_labels = kwargs.get("subset_labels", [])
     bins = bins or [getattr(viewer.state, "bins", None) for viewer in viewers]
     subsets = []
+    original_colors = []
 
     deselected_color = "#a9a9a9"
 
@@ -37,3 +43,103 @@ def PercentageSelector(viewers, glue_data, bins=None, **kwargs):
     def _bin_bounds(value, bins):
         index = next((idx for idx, x in enumerate(bins) if x >= value), 0)
         return bins[index - 1], bins[index]
+
+    def _rounded_bound(bound):
+        if resolution is None:
+            return bound
+        return round(bound, resolution)
+
+    def _bin_rounded_bound(bound, bins):
+        rounded_bound = _rounded_bound(bound)
+        res = 10 ** (resolution)
+        rounded_bin_bounds = _bin_bounds(bound, bins)
+        if bound < rounded_bin_bounds[0]:
+            rounded_bound -= res 
+        elif bound > rounded_bin_bounds[1]:
+            rounded_bound += res 
+        return rounded_bound
+
+    last_selected = None
+    def _update(selected):
+        nonlocal original_colors, last_selected
+        layers = [viewer.layer_artist_for_data(data)
+                  for (data, viewer) in zip(glue_data, viewers)]
+        if last_selected:
+            original_colors = [layer.state.color for layer in layers]
+
+        if selected is None:
+            states = []
+            for (index, viewer) in enumerate(viewers):
+                if layers[index] is not None:
+                    layers[index].state.color = original_colors[index]
+                    # viewer_layouts[index].set_subtitle(None)
+                state = array([False for _ in range(glue_data[index].size)])
+                states.append(state)
+            _update_subsets(states)
+            return
+
+        states = []
+        for index, (viewer, bins) in enumerate(zip(viewers, bins)):
+            component_id = viewer.state.x_att
+            data = glue_data[index][component_id]
+            layer = layers[index]
+            layer.state.color = deselected_color
+            bottom_index, top_index = percent_around_center_indices(data.size, selected)
+    
+            sorted_indices = argsort(data)
+            true_bottom = data[sorted_indices[bottom_index]]
+            true_top = data[sorted_indices[top_index]]
+            expected_count = round(selected * data.size / 100)
+            actual_count = top_index - bottom_index + 1
+            if expected_count != actual_count:
+                median = glue_data[index].compute_statistic('median', viewer.state.x_att)
+                if expected_count < actual_count:
+                    dist_bottom = abs(median - true_bottom)
+                    dist_top = abs(median - true_top)
+                    new_bottom_index = bottom_index + 1
+                    new_top_index = top_index - 1
+
+                    if dist_bottom > dist_top:
+                        bottom_index = new_bottom_index
+                        true_bottom = data[sorted_indices[bottom_index]]
+                    else:
+                        top_index = new_top_index
+                        true_top = data[sorted_indices[top_index]]
+                else:
+                    new_bottom_index = max(0, bottom_index - 1)
+                    new_bottom = data[sorted_indices[new_bottom_index]]
+                    new_top_index = min(top_index + 1, data.size - 1)
+                    new_bottom = data[sorted_indices[new_top_index]]
+                    dist_bottom = abs(median - new_bottom)
+                    dist_top = abs(median - new_bottom)
+
+                    if dist_bottom < dist_top or new_top_index == data.size - 1:
+                        bottom_index = new_bottom_index
+                        true_bottom = data[sorted_indices[bottom_index]]
+                    else:
+                        top_index = new_top_index
+                        true_top = data[sorted_indices[top_index]]
+
+            # Ideally we could use something like a RangeSubsetState
+            # but this can be problematic for our case when there are a small number
+            # of data points and low resolution, since then repeated values will
+            # have a very noticeable bad effect on the size that we're choosing
+            # If in the future we have a situation where we want to do this with more fluid
+            # data, we'll need to list to an update message or something to recalculate the
+            # indices here
+            indices = [si for i, si in enumerate(sorted_indices) if i >= bottom_index and i <= top_index]
+            state = ElementSubsetState(indices=indices)
+            states.append(state)
+            rounded_bottom = _bin_rounded_bound(true_bottom, bins)
+            rounded_top = _bin_rounded_bound(true_top, bins)
+
+            bottom_str = "{:g}".format(rounded_bottom)
+            top_str = "{:g}".format(rounded_top)
+            if units and units[index]:
+                unit_str = f" {units[index]}"
+            else:
+                unit_str = ""
+            label_text = f"{selected}% range: {bottom_str} \u2013 {top_str}{unit_str}"
+            # self.viewer_layouts[index].set_subtitle(label_text)
+
+        _update_subsets(states)

--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -1,0 +1,39 @@
+import solara
+
+
+@solara.component
+def PercentageSelector(viewers, glue_data, bins=None, **kwargs):
+    
+    radio_color = "#1e90ff"
+    options = [50, 68, 95]
+    selected = None
+    resolution = kwargs.get("resolution", None)
+    subset_group = kwargs.get("subset_group", False)
+    subset_labels = kwargs.get("subset_labels", [])
+    bins = bins or [getattr(viewer.state, "bins", None) for viewer in viewers]
+    subsets = []
+
+    deselected_color = "#a9a9a9"
+
+    def _update_subsets(states):
+        if not subsets:
+            kwargs = { "alpha": 1 }
+            session = viewers[0].session
+            for index in range(len(viewers)):
+                data = glue_data[index]
+                state = states[index]
+                if subset_labels:
+                    kwargs["label"] = subset_labels[index]
+                if subset_group:
+                    subset = session.data_collection.new_subset_group(state, **kwargs)
+                else:
+                    subset = data.new_subset(state, **kwargs)
+                    viewers[index].add_subset(subset)
+                subsets.append(subset)
+        else:
+            for subset, state in zip(subsets, states):
+                subset.subset_state = state
+
+    def _bin_bounds(value, bins):
+        index = next((idx for idx, x in enumerate(bins) if x >= value), 0)
+        return bins[index - 1], bins[index]

--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -8,6 +8,7 @@ from glue.core.subset import ElementSubsetState
 from ..utils import percent_around_center_indices
 
 from glue.viewers.common.viewer import Viewer
+from numbers import Number
 from typing import Iterable, List
 
 
@@ -15,7 +16,7 @@ from typing import Iterable, List
 def PercentageSelector(viewers: List[Viewer],
                        glue_data: List[Viewer],
                        selected: Reactive[str | None],
-                       bins: None | List[None | Iterable[None | int | float]]=None,
+                       bins: None | List[None | Iterable[None | Number]]=None,
                        **kwargs):
     
     radio_color = "#1e90ff"

--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -173,9 +173,25 @@ def PercentageSelector(viewers, glue_data, bins=None, **kwargs):
                                   label=f"{option}%",
                                   on_value=lambda value, option=option: _update_selected(option, value))
                     rv.Dialog(
+                        class_="percentage-help-dialog",
                         v_slots=[{"name": "activator",
                                   "variable": "x",
-                                  "children": [solara.IconButton(v_on="x.on", icon_name="mdi-circle-help-outline")]
+                                  "children": [solara.IconButton(v_on="x.on",
+                                                                 icon_name="mdi-circle-help-outline")]
                                 }],
-                        children=[solara.Text("TEST")]
+                        children=[
+                            rv.Card(children=[
+                                rv.Toolbar(children=[
+                                    rv.ToolbarTitle(children=[f"Inner {option}% of the data"]),
+                                    rv.Spacer(),
+                                ]),
+                                solara.Text(f"""
+                                            The range of values shown are the inner {option}% of data points.
+                                            This means that the {(100-option)/2}% of the data points in the distribution
+                                            have values less than this range, and {(100-option)/2}% of the data points
+                                            have values greater than this range
+                                            """)
+                                              
+                            ])
+                        ]
                     )

--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -1,14 +1,22 @@
 from numpy import argsort, array
 import solara
+from solara import Reactive
 import reacton.ipyvuetify as rv
 
 from glue.core.subset import ElementSubsetState
 
 from ..utils import percent_around_center_indices
 
+from glue.viewers.common.viewer import Viewer
+from typing import Iterable, List
+
 
 @solara.component
-def PercentageSelector(viewers, glue_data, bins=None, **kwargs):
+def PercentageSelector(viewers: List[Viewer],
+                       glue_data: List[Viewer],
+                       selected: Reactive[str | None],
+                       bins: None | List[None | Iterable[None | int | float]]=None,
+                       **kwargs):
     
     radio_color = "#1e90ff"
     options = [50, 68, 95]

--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -21,7 +21,6 @@ def PercentageSelector(viewers: List[Viewer],
     
     radio_color = "#1e90ff"
     options = [50, 68, 95]
-    selected = solara.use_reactive(None)
     last_updated = None
     resolution = kwargs.get("resolution", 0)
     subset_group = kwargs.get("subset_group", False)

--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -167,7 +167,15 @@ def PercentageSelector(viewers, glue_data, bins=None, **kwargs):
     with rv.Card():
         with rv.Container():
             for option in options:
-                model = _model_factory(option)
-                solara.Switch(value=model,
-                              label=f"{option}%",
-                              on_value=lambda value, option=option: _update_selected(option, value))
+                with rv.Row():
+                    model = _model_factory(option)
+                    solara.Switch(value=model,
+                                  label=f"{option}%",
+                                  on_value=lambda value, option=option: _update_selected(option, value))
+                    rv.Dialog(
+                        v_slots=[{"name": "activator",
+                                  "variable": "x",
+                                  "children": [solara.IconButton(v_on="x.on", icon_name="mdi-circle-help-outline")]
+                                }],
+                        children=[solara.Text("TEST")]
+                    )

--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -167,8 +167,8 @@ def PercentageSelector(viewers, glue_data, bins=None, **kwargs):
     with rv.Card():
         with rv.Container():
             for option in options:
-                with rv.Row():
-                    model = _model_factory(option)
+                model = _model_factory(option)
+                with solara.Row(style={"align-items": "center"}):
                     solara.Switch(value=model,
                                   label=f"{option}%",
                                   on_value=lambda value, option=option: _update_selected(option, value))
@@ -177,7 +177,7 @@ def PercentageSelector(viewers, glue_data, bins=None, **kwargs):
                         v_slots=[{"name": "activator",
                                   "variable": "x",
                                   "children": [solara.IconButton(v_on="x.on",
-                                                                 icon_name="mdi-circle-help-outline")]
+                                                                 icon_name="mdi-help-circle-outline")]
                                 }],
                         children=[
                             rv.Card(children=[

--- a/src/cosmicds/components/statistics_selector.py
+++ b/src/cosmicds/components/statistics_selector.py
@@ -1,0 +1,102 @@
+from cosmicds.utils import vertical_line_mark
+import solara
+import reacton.ipyvuetify as rv
+from uuid import uuid4
+
+from typing import List
+
+from ...utils import mode
+
+
+# glue doesn't implement a mode statistic, so we roll our own
+# Since there can be multiple modes, mode can be a list
+# and so we return a list for every statistic to make things simpler
+def find_statistic(stat, viewer, data, bins):
+    if stat == "mode":
+        return mode(data, viewer.state.x_att, bins=bins, range=[viewer.state.hist_x_min, viewer.state.hist_x_max])
+    else:
+        return [data.compute_statistic(stat, viewer.state.x_att)]
+
+
+@solara.component
+def StatisticsSelector(viewers, glue_data, units, bins=None, statistics=["mean", "median", "mode"], **kwargs):
+
+    transform = kwargs.get("transform", None)
+    color = kwargs.get("color", "#000000")
+    line_ids = []
+    bins = bins or [getattr(viewer.state, "bins", None) for viewer in viewers]
+
+    help_text = {
+        "mode": "Description of the mode",
+        "mean": "Description of the mean",
+        "median": "Description of the median",
+    }
+
+    last_updated = None
+    selected = solara.use_reactive(None)
+
+    def _remove_lines():
+        for (viewer, viewer_line_ids) in zip(viewers, line_ids):
+            lines = list(viewer.figure.select_traces(lambda t: t.meta in viewer_line_ids))
+            viewer.figure.data = [t for t in viewer.figure.data if t not in lines]
+            
+    def _update_lines():
+        stat = selected.value
+        if last_updated == stat:
+            return stat
+
+        if last_updated is not None:
+            _remove_lines()
+
+        if stat is None:
+            return None
+
+        line_ids.clear()
+        for viewer, d, bin, unit in zip(viewers, glue_data, bins, units):
+            viewer_lines = []
+            viewer_line_ids = []
+            try:
+                capitalized = stat.capitalize()
+                values = find_statistic(stat, viewer, d, bin)
+                if transform is not None:
+                    values = [transform(v) for v in values]
+                for value in values:
+                    label = f"{capitalized}: {value}"
+                    if unit:
+                        label += f" {unit}"
+                    line_id = str(uuid4())
+                    line = vertical_line_mark(viewer.layers[0], value, color, label=label)
+                    line["meta"] = line_id
+                    viewer_lines.append(line)
+                    viewer_line_ids.append(line_id)
+            except ValueError:
+                pass
+
+            # The Scatter traces that get added aren't the same instances
+            # as those we pass in. So we need to grab references to them
+            # AFTER they've been added
+            viewer.figure.add_traces(viewer_lines)
+            line_ids.append(viewer_line_ids)
+
+        return stat
+
+
+    def _update_selected(stat, value):
+        nonlocal last_updated
+        if value:
+            selected.set(stat)
+        elif selected.value == stat:
+            selected.set(None)
+        last_updated = _update_lines()
+
+    def _model_factory(stat):
+        return solara.lab.computed(lambda stat=stat: selected.value == stat)
+
+    with rv.Card():
+        with rv.Container():
+            for stat in statistics:
+                model = _model_factory(stat)
+                # We need to bind the current value of `stat` to the lambda
+                solara.Switch(value=model,
+                              label=stat.capitalize(),
+                              on_value=lambda value, stat=stat: _update_selected(stat, value))

--- a/src/cosmicds/components/statistics_selector.py
+++ b/src/cosmicds/components/statistics_selector.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from typing import List
 
-from ...utils import mode
+from ..utils import mode
 
 
 # glue doesn't implement a mode statistic, so we roll our own

--- a/src/cosmicds/components/statistics_selector.py
+++ b/src/cosmicds/components/statistics_selector.py
@@ -31,6 +31,11 @@ def StatisticsSelector(viewers, glue_data, units, bins=None, statistics=["mean",
         "mean": "Description of the mean",
         "median": "Description of the median",
     }
+    help_images = {
+        "mode": "path to mode image",
+        "mean": "path to mean image",
+        "median": "path to median image"
+    }
 
     last_updated = None
     selected = solara.use_reactive(None)
@@ -96,7 +101,23 @@ def StatisticsSelector(viewers, glue_data, units, bins=None, statistics=["mean",
         with rv.Container():
             for stat in statistics:
                 model = _model_factory(stat)
-                # We need to bind the current value of `stat` to the lambda
                 solara.Switch(value=model,
                               label=stat.capitalize(),
                               on_value=lambda value, stat=stat: _update_selected(stat, value))
+                rv.Dialog(
+                        class_="percentage-help-dialog",
+                        v_slots=[{"name": "activator",
+                                  "variable": "x",
+                                  "children": [solara.IconButton(v_on="x.on",
+                                                                 icon_name="mdi-circle-help-outline")]
+                                }],
+                        children=[
+                            rv.Card(children=[
+                                rv.Toolbar(children=[
+                                    rv.ToolbarTitle(children=[stat.capitalize()]),
+                                    rv.Spacer(),
+                                ]),
+                                solara.Text(help_text[stat])
+                            ])
+                        ]
+                    )

--- a/src/cosmicds/components/statistics_selector.py
+++ b/src/cosmicds/components/statistics_selector.py
@@ -6,7 +6,8 @@ from uuid import uuid4
 
 from glue.core import Data
 from glue.viewers.common.viewer import Viewer
-from typing import Iterable, List 
+from numbers import Number
+from typing import Callable, Iterable, List 
 
 from ..utils import mode
 
@@ -26,11 +27,11 @@ def StatisticsSelector(viewers: List[Viewer],
                        glue_data: List[Data],
                        units: List[str],
                        selected: Reactive[str | None],
-                       bins: None | List[None | Iterable[int | float]]=None,
+                       bins: None | List[None | Iterable[Number]]=None,
                        statistics: List[str]=["mean", "median", "mode"],
+                       transform: Callable[[Number], Number] | None=None,
                        **kwargs):
 
-    transform = kwargs.get("transform", None)
     color = kwargs.get("color", "#000000")
     line_ids = []
     bins = bins or [getattr(viewer.state, "bins", None) for viewer in viewers]

--- a/src/cosmicds/components/statistics_selector.py
+++ b/src/cosmicds/components/statistics_selector.py
@@ -101,23 +101,24 @@ def StatisticsSelector(viewers, glue_data, units, bins=None, statistics=["mean",
         with rv.Container():
             for stat in statistics:
                 model = _model_factory(stat)
-                solara.Switch(value=model,
-                              label=stat.capitalize(),
-                              on_value=lambda value, stat=stat: _update_selected(stat, value))
-                rv.Dialog(
-                        class_="percentage-help-dialog",
-                        v_slots=[{"name": "activator",
-                                  "variable": "x",
-                                  "children": [solara.IconButton(v_on="x.on",
-                                                                 icon_name="mdi-circle-help-outline")]
-                                }],
-                        children=[
-                            rv.Card(children=[
-                                rv.Toolbar(children=[
-                                    rv.ToolbarTitle(children=[stat.capitalize()]),
-                                    rv.Spacer(),
-                                ]),
-                                solara.Text(help_text[stat])
-                            ])
-                        ]
-                    )
+                with solara.Row(style={"align-items": "center"}):
+                    solara.Switch(value=model,
+                                  label=stat.capitalize(),
+                                  on_value=lambda value, stat=stat: _update_selected(stat, value))
+                    rv.Dialog(
+                            class_="statistics-help-dialog",
+                            v_slots=[{"name": "activator",
+                                      "variable": "x",
+                                      "children": [solara.IconButton(v_on="x.on",
+                                                                     icon_name="mdi-help-circle-outline")]
+                                    }],
+                            children=[
+                                rv.Card(children=[
+                                    rv.Toolbar(children=[
+                                        rv.ToolbarTitle(children=[stat.capitalize()]),
+                                        rv.Spacer(),
+                                    ]),
+                                    solara.Text(help_text[stat])
+                                ])
+                            ]
+                        )

--- a/src/cosmicds/components/statistics_selector.py
+++ b/src/cosmicds/components/statistics_selector.py
@@ -1,9 +1,12 @@
 from cosmicds.utils import vertical_line_mark
 import solara
+from solara import Reactive
 import reacton.ipyvuetify as rv
 from uuid import uuid4
 
-from typing import List
+from glue.core import Data
+from glue.viewers.common.viewer import Viewer
+from typing import Iterable, List 
 
 from ..utils import mode
 
@@ -11,7 +14,7 @@ from ..utils import mode
 # glue doesn't implement a mode statistic, so we roll our own
 # Since there can be multiple modes, mode can be a list
 # and so we return a list for every statistic to make things simpler
-def find_statistic(stat, viewer, data, bins):
+def find_statistic(stat: str, viewer: Viewer, data: Data, bins: Iterable[int | float] | None):
     if stat == "mode":
         return mode(data, viewer.state.x_att, bins=bins, range=[viewer.state.hist_x_min, viewer.state.hist_x_max])
     else:
@@ -19,7 +22,13 @@ def find_statistic(stat, viewer, data, bins):
 
 
 @solara.component
-def StatisticsSelector(viewers, glue_data, units, bins=None, statistics=["mean", "median", "mode"], **kwargs):
+def StatisticsSelector(viewers: List[Viewer],
+                       glue_data: List[Data],
+                       units: List[str],
+                       selected: Reactive[str | None],
+                       bins: None | List[None | Iterable[int | float]]=None,
+                       statistics: List[str]=["mean", "median", "mode"],
+                       **kwargs):
 
     transform = kwargs.get("transform", None)
     color = kwargs.get("color", "#000000")
@@ -38,7 +47,6 @@ def StatisticsSelector(viewers, glue_data, units, bins=None, statistics=["mean",
     }
 
     last_updated = None
-    selected = solara.use_reactive(None)
 
     def _remove_lines():
         for (viewer, viewer_line_ids) in zip(viewers, line_ids):

--- a/src/cosmicds/components/viewer_layout.py
+++ b/src/cosmicds/components/viewer_layout.py
@@ -1,3 +1,4 @@
+from cosmicds.utils import make_figure_autoresize
 import solara
 
 __all__ = ["ToolBar", "ViewerLayout"]
@@ -17,7 +18,7 @@ def ToolBar(viewer):
 
 @solara.component
 def ViewerLayout(viewer):
-    viewer.figure_widget.layout.height = 600
+    make_figure_autoresize(viewer.figure_widget, 400)
     layout = solara.Column(
         children=[
             ToolBar(viewer),

--- a/src/cosmicds/utils.py
+++ b/src/cosmicds/utils.py
@@ -372,6 +372,14 @@ def mode(data, component_id, bins=None, range=None):
         return [k for k, v in counter.items() if v == max_count]
 
 
+def make_figure_autoresize(figure, height=400):
+    # The auto-sizing in the Plotly widget only works if the height
+    # and width are undefined. First, unset the height and width,
+    # then enable auto-sizing.
+    figure.update_layout(height=None, width=None)
+    figure.update_layout(autosize=True, height=height)
+
+
 def request_session():
     """
     Returns a `requests.Session` object that has the relevant authorization parameters


### PR DESCRIPTION
This PR ports the statistics and percentage selectors over to Solara. The logic of these was mostly Python-side anyway, so I decided to just go ahead and move the layout side to Solara as well. Additionally, this adds a utility function based on what @nmearl did for the dotplot viewer to encapsulate the operations for making a Plotly figure resizable.

These mostly behave the same way as they did previously, but any thoughts or tweaks to the layout are welcome.