### PR TITLE
Fix StateEditor to control nested states

### DIFF
--- a/src/cosmicds/components/debug_control.py
+++ b/src/cosmicds/components/debug_control.py
@@ -2,7 +2,7 @@ import solara
 from solara import Reactive
 import reacton.ipyvuetify as rv
 
-from dataclasses import fields
+from dataclasses import fields, is_dataclass
 
 from functools import partial
 
@@ -41,6 +41,16 @@ def FieldList(component_state):
         elif isinstance(field_type, Reactive):
             # just print it out
             solara.Markdown(f"{field['name']}: {field_attr.value}")
+        elif is_dataclass(field_type):
+            # recursively call this function
+            with solara.Card(style="border-radius: 5px; border: 2px solid #40ECB2; max-width: 400px"):
+                with solara.Details(summary=f"{field['name']}:"):
+                    FieldList(field_attr)
+        elif isinstance(field_type, Reactive) and is_dataclass(field_type.value):
+            # recursively call this function
+            with solara.Card(style="border-radius: 5px; border: 2px solid #40ECB2; max-width: 400px"):
+                with solara.Details(summary=f"{field['name']}:"):
+                    FieldList(field_attr.value)
         else:
              solara.Markdown(f"{field['name']}: {field_attr}")
 


### PR DESCRIPTION
Fixes the StateEditor so that it does not break when trying to load nested states. The StateEditor would crash if it encountered a `<Reactive>` in the markdown. Now "sub states" are properly (recursively) rendered

<img width="372" alt="image" src="https://github.com/cosmicds/cosmicds/assets/7862929/a1d0eb70-67ad-4c9e-be09-ba9b84464842">
