### PR TITLE
Use Plotly histogram viewer state

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     echo
     glue-core
     glue-jupyter
-    glue-plotly>=0.7.2
+    glue-plotly>=0.7.4
     httpx
     ipyvuetify
     numpy<2.0.0

--- a/src/cosmicds/viewers/state.py
+++ b/src/cosmicds/viewers/state.py
@@ -4,6 +4,7 @@ from echo import add_callback, callback_property, delay_callback, CallbackProper
 from glue.core import Subset
 from glue.viewers.histogram.state import HistogramViewerState
 from glue.viewers.scatter.state import ScatterViewerState
+from glue_plotly.viewers.histogram.state import PlotlyHistogramViewerState
 from numpy import linspace, inf, isfinite, isnan, spacing
 
 from cosmicds.utils import frexp10
@@ -172,7 +173,7 @@ class CDSScatterViewerState(ScatterViewerState):
 
 
 
-class CDSHistogramViewerState(HistogramViewerState):
+class CDSHistogramViewerState(PlotlyHistogramViewerState):
 
     def _reset_x_limits(self):
         bounds = []


### PR DESCRIPTION
This PR updates our histogram viewer states to wrap the histogram viewer state from `glue-plotly`, as this now has extra callback properties not present on the base glue viewer state. This fixes the error that we're seeing during the stress test.