### PR TITLE
Updates to handle student data

### DIFF
--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -5,7 +5,7 @@ from importlib.metadata import version
 
 import solara
 from solara.alias import rv
-from solara.lab import theme as theme, Ref
+from solara.lab import theme, Ref
 from solara.server import settings
 from solara_enterprise import auth
 from solara import Reactive
@@ -66,21 +66,26 @@ def BaseLayout(
 
     solara.use_memo(_load_from_cache)
 
-    if bool(auth.user.value):
-        if BASE_API.user_exists:
-            BASE_API.load_user_info(story_name, GLOBAL_STATE)
-        elif bool(class_code.value):
-            BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
-        else:
-            logger.error("User is authenticated, but does not exist.")
-            solara.use_router().push(auth.get_logout_url())
-    else:
-        logger.info("User has not authenticated.")
-        BASE_API.clear_user(GLOBAL_STATE)
+    # if bool(auth.user.value):
+    #     if BASE_API.user_exists:
+    #         BASE_API.load_user_info(story_name, GLOBAL_STATE)
+    #     elif bool(class_code.value):
+    #         BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
+    #     else:
+    #         logger.error("User is authenticated, but does not exist.")
+    #         solara.use_router().push(auth.get_logout_url())
+    # else:
+    #     logger.info("User has not authenticated.")
+    #     BASE_API.clear_user(GLOBAL_STATE)
 
-        login_dialog = Login(active, class_code, update_db, debug_mode)
-        active.set(True)
-        return
+    #     login_dialog = Login(active, class_code, update_db, debug_mode)
+    #     active.set(True)
+    #     return
+
+    # TODO: This is just for testing!
+    Ref(GLOBAL_STATE.fields.student.id).set(0)
+    Ref(GLOBAL_STATE.fields.classroom.class_info).set({"id": 0})
+    Ref(GLOBAL_STATE.fields.classroom.size).set(0)
 
     @solara.lab.computed
     def display_info():

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -66,26 +66,26 @@ def BaseLayout(
 
     solara.use_memo(_load_from_cache)
 
-    # if bool(auth.user.value):
-    #     if BASE_API.user_exists:
-    #         BASE_API.load_user_info(story_name, GLOBAL_STATE)
-    #     elif bool(class_code.value):
-    #         BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
-    #     else:
-    #         logger.error("User is authenticated, but does not exist.")
-    #         solara.use_router().push(auth.get_logout_url())
-    # else:
-    #     logger.info("User has not authenticated.")
-    #     BASE_API.clear_user(GLOBAL_STATE)
+    if bool(auth.user.value):
+        if BASE_API.user_exists:
+            BASE_API.load_user_info(story_name, GLOBAL_STATE)
+        elif bool(class_code.value):
+            BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
+        else:
+            logger.error("User is authenticated, but does not exist.")
+            solara.use_router().push(auth.get_logout_url())
+    else:
+        logger.info("User has not authenticated.")
+        BASE_API.clear_user(GLOBAL_STATE)
 
-    #     login_dialog = Login(active, class_code, update_db, debug_mode)
-    #     active.set(True)
-    #     return
+        login_dialog = Login(active, class_code, update_db, debug_mode)
+        active.set(True)
+        return
 
-    # TODO: This is just for testing!
-    Ref(GLOBAL_STATE.fields.student.id).set(0)
-    Ref(GLOBAL_STATE.fields.classroom.class_info).set({"id": 0})
-    Ref(GLOBAL_STATE.fields.classroom.size).set(0)
+    # Just for testing
+    # Ref(GLOBAL_STATE.fields.student.id).set(0)
+    # Ref(GLOBAL_STATE.fields.classroom.class_info).set({"id": 0})
+    # Ref(GLOBAL_STATE.fields.classroom.size).set(0)
 
     @solara.lab.computed
     def display_info():

--- a/src/cosmicds/state.py
+++ b/src/cosmicds/state.py
@@ -3,6 +3,7 @@ from functools import cached_property
 from glue_jupyter import JupyterApplication
 from glue.core import DataCollection, Session
 import solara
+from glue.core import Data, DataCollection
 
 
 class BaseState(BaseModel):
@@ -51,6 +52,15 @@ class GlobalState(BaseState):
     @cached_property
     def glue_session(self) -> Session:
         return self._glue_app.session
+    
+    def add_or_update_data(self, data: Data):
+        if data.label in self.glue_data_collection:
+            existing = self.glue_data_collection[data.label]
+            existing.update_values_from_data(data)
+            return existing
+        else:
+            self.glue_data_collection.append(data)
+            return data
 
 
-GLOBAL_STATE = solara.reactive(GlobalState())
+GLOBAL_STATE = GlobalState()

--- a/src/cosmicds/state.py
+++ b/src/cosmicds/state.py
@@ -63,4 +63,4 @@ class GlobalState(BaseState):
             return data
 
 
-GLOBAL_STATE = GlobalState()
+GLOBAL_STATE = solara.reactive(GlobalState())

--- a/src/cosmicds/utils.py
+++ b/src/cosmicds/utils.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from datetime import datetime
 import json
 from numbers import Number
 import os
@@ -60,6 +61,8 @@ class CDSJSONEncoder(json.JSONEncoder):
             return obj.tolist()
         if isinstance(obj, State):
             return obj.as_dict()
+        if isinstance(obj, datetime):
+            return f"{obj}"
         return super(CDSJSONEncoder, self).default(obj)
 
 

--- a/src/cosmicds/utils.py
+++ b/src/cosmicds/utils.py
@@ -412,7 +412,7 @@ def mode(data, component_id, bins=None, range=None):
         return [k for k, v in counter.items() if v == max_count]
 
 
-def empty_data_from_model_class(cls: Type[BaseModel]):
+def empty_data_from_model_class(cls: Type[BaseModel], label: str | None=None):
     data_dict = {}
     for field, info in cls.model_fields.items():
         if info.annotation is None:
@@ -425,6 +425,8 @@ def empty_data_from_model_class(cls: Type[BaseModel]):
             numerical = True
 
         data_dict[field] = Component(np.array([])) if numerical else CategoricalComponent(np.array([]))
+    if label:
+        data_dict["label"] = label
     return Data(**data_dict)
 
 

--- a/src/cosmicds/utils.py
+++ b/src/cosmicds/utils.py
@@ -8,6 +8,7 @@ from types import UnionType
 from glue.core import Component, Data
 from glue.core.roi import CategoricalComponent
 from pydantic import BaseModel
+from pydantic.fields import FieldInfo
 from requests import adapters
 import random
 from typing import Type, Union, get_args, get_origin
@@ -415,19 +416,27 @@ def mode(data, component_id, bins=None, range=None):
         return [k for k, v in counter.items() if v == max_count]
 
 
+def component_type_for_field(info: FieldInfo) -> Type[Component]:
+    if info.annotation is None:
+        return Component  # TODO: What is the right result here?
+    numerical = False
+    if get_origin(info.annotation) in (Union, UnionType):
+        types = get_args(info.annotation)
+        numerical = all(t is None or issubclass(t, Number) for t in types)
+    elif issubclass(info.annotation, Number):
+        numerical = True
+
+    return Component if numerical else CategoricalComponent
+
+
 def empty_data_from_model_class(cls: Type[BaseModel], label: str | None=None):
     data_dict = {}
     for field, info in cls.model_fields.items():
         if info.annotation is None:
             continue
-        numerical = False
-        if get_origin(info.annotation) in (Union, UnionType):
-            types = get_args(info.annotation)
-            numerical = all(t is None or issubclass(t, Number) for t in types)
-        elif issubclass(info.annotation, Number):
-            numerical = True
 
-        data_dict[field] = Component(np.array([])) if numerical else CategoricalComponent(np.array([]))
+        component_type = component_type_for_field(info)
+        data_dict[field] = component_type(np.array([]))
     if label:
         data_dict["label"] = label
     return Data(**data_dict)

--- a/src/cosmicds/viewers/__init__.py
+++ b/src/cosmicds/viewers/__init__.py
@@ -17,7 +17,6 @@ CDSScatterView = cds_viewer(
     viewer_tools=[
         'plotly:home',
         'plotly:zoom',
-        'plotly:rectangle'
     ],
     label='2D scatter'
 )
@@ -29,7 +28,6 @@ CDSHistogramView = cds_viewer(
     viewer_tools=[
         'plotly:home',
         'plotly:hzoom',
-        'plotly:xrange'
     ],
     label='Histogram'
 )


### PR DESCRIPTION
This PR contains some various updates to the base package. These are issues that popped up while I was working on using the real student data in stages 4 + 5 of the Hubble app, but should be generally useful changes. The main changes include:

* Remove the subset selection tools from our base CosmicDS viewers, since we tend to not give students the ability to make selections by default
* Allow our JSON encoder to serialize `datetime` objects
* Add a method to the global state to allow either adding data (if it's not present) or updating existing data, based on the data's label. Using this method prevents accidentally adding the same data to the data collection twice
* Add a utility function for creating an empty glue `Data` object with appropriately-typed components from a `pydantic` model class