### PR TITLE
Add button for refreshing stage state and refactor API functionality

### DIFF
--- a/src/cosmicds/components/__init__.py
+++ b/src/cosmicds/components/__init__.py
@@ -6,3 +6,4 @@ from .debug_control import StateEditor
 from .layer_toggle import LayerToggle
 from .statistics_selector import StatisticsSelector
 from .percentage_selector import PercentageSelector
+from .refresh_button import RefreshButton

--- a/src/cosmicds/components/debug_control.py
+++ b/src/cosmicds/components/debug_control.py
@@ -3,9 +3,9 @@ from solara import Reactive
 from solara.toestand import Ref
 import reacton.ipyvuetify as rv
 
-
 from cosmicds.remote import BaseAPI
 
+from .refresh_button import RefreshButton
 from ..state import GLOBAL_STATE, BaseLocalState, BaseState
 
 from enum import Enum
@@ -111,11 +111,5 @@ def StateEditor(marker_cls: Type[Enum],
             )
         
         with solara.Row():
-            def _reset_stage_state():
-                api.delete_stage_state(GLOBAL_STATE, local_state, component_state)
-                router = solara.use_router()
-                router.push(router.path)
-            solara.Button(
-                children="Reset Stage State",
-                on_click=lambda: _reset_stage_state()
-            )
+            RefreshButton(event_before_refresh=lambda _: api.delete_stage_state(GLOBAL_STATE, local_state, component_state),
+                          button_text="Reset Stage State")

--- a/src/cosmicds/components/debug_control.py
+++ b/src/cosmicds/components/debug_control.py
@@ -1,15 +1,17 @@
 import solara
-from solara import Reactive, TypeVar
+from solara import Reactive
 from solara.toestand import Ref
 import reacton.ipyvuetify as rv
 
-from pydantic import BaseModel
 
-from ..state import GLOBAL_STATE, BaseState
+from cosmicds.remote import BaseAPI
+
+from ..state import GLOBAL_STATE, BaseLocalState, BaseState
 
 from enum import Enum
 from functools import partial
 from typing import Type
+
 
 @solara.component
 def MarkerSelector(marker_cls: Type[Enum], component_state: Reactive[BaseState]):
@@ -72,7 +74,10 @@ def FieldList(component_state: Reactive[BaseState]):
 
 
 @solara.component
-def StateEditor(marker_cls: Type[Enum], component_state: Reactive[BaseState]):
+def StateEditor(marker_cls: Type[Enum],
+                component_state: Reactive[BaseState],
+                local_state: Reactive[BaseLocalState],
+                api: BaseAPI):
     show_dialog, set_show_dialog = solara.use_state(False)
     with solara.Card(style="border-radius: 5px; border: 2px solid #EC407A; max-width: 400px"):
         with solara.Row():
@@ -103,4 +108,14 @@ def StateEditor(marker_cls: Type[Enum], component_state: Reactive[BaseState]):
         else:
             solara.Markdown(
                 "End of Stage"
+            )
+        
+        with solara.Row():
+            def _reset_stage_state():
+                api.delete_stage_state(GLOBAL_STATE, local_state, component_state)
+                router = solara.use_router()
+                router.push(router.path)
+            solara.Button(
+                children="Reset Stage State",
+                on_click=lambda: _reset_stage_state()
             )

--- a/src/cosmicds/components/refresh_button/RefreshButton.vue
+++ b/src/cosmicds/components/refresh_button/RefreshButton.vue
@@ -1,0 +1,22 @@
+<template>
+  <v-btn
+    @click="() => {
+      if (before_refresh) {
+        before_refresh();
+      }
+      refresh();
+    }"
+  >
+    {{ button_text }}
+  </v-btn>
+</template>
+
+<script>
+export default {
+  methods: {
+    refresh() {
+      location.reload();
+    }
+  }
+}
+</script>

--- a/src/cosmicds/components/refresh_button/__init__.py
+++ b/src/cosmicds/components/refresh_button/__init__.py
@@ -1,0 +1,1 @@
+from .refresh_button import RefreshButton  # noqa

--- a/src/cosmicds/components/refresh_button/refresh_button.py
+++ b/src/cosmicds/components/refresh_button/refresh_button.py
@@ -1,0 +1,10 @@
+import solara
+
+
+@solara.component_vue("RefreshButton.vue")
+def RefreshButton(
+    event_before_refresh=None,
+    button_text="Refresh"
+):
+    pass
+

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -207,22 +207,7 @@ class BaseAPI:
         global_state: Reactive[GlobalState],
         local_state: Reactive[BaseLocalState],
     ):
-        logger.info("Serializing state into DB.")
-
-        state = {
-            "app": global_state.value.dict(),
-            "story": local_state.value.dict(
-                exclude={"measurements", "example_measurements"}
-            ),
-        }
-
-        r = self.request_session.put(
-            f"{self.API_URL}/story-state/{global_state.value.student.id}/{local_state.value.story_id}",
-            json=state,
-        )
-
-        if r.status_code != 200:
-            logger.error("Failed to write story state to database.")
+       raise NotImplementedError() 
 
     @staticmethod
     def clear_user(state: Reactive[GlobalState]):

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -3,7 +3,8 @@ import hashlib
 import os
 from requests import Session
 from functools import cached_property
-from .state import GlobalState
+
+from .state import BaseLocalState, BaseState, GlobalState
 from solara import Reactive
 from solara.lab import Ref
 from cosmicds.logger import setup_logger
@@ -102,6 +103,126 @@ class BaseAPI:
         )
 
         self.load_user_info(story_name, state)
+
+    def put_stage_state(
+        self,
+        global_state: Reactive[GlobalState],
+        local_state: Reactive[BaseLocalState],
+        component_state: Reactive[BaseState],
+    ):
+        raise NotImplementedError()
+
+    def get_stage_state(
+        self,
+        global_state: Reactive[GlobalState],
+        local_state: Reactive[BaseLocalState],
+        component_state: Reactive[BaseState],
+    ) -> BaseState | None:
+        stage_json = (
+            self.request_session.get(
+                f"{self.API_URL}/stage-state/{global_state.value.student.id}/"
+                f"{local_state.value.story_id}/{component_state.value.stage_id}"
+            )
+            .json()
+            .get("state", None)
+        )
+
+        if stage_json is None:
+            logger.error(
+                "Failed to retrieve stage state for story `%s` for user `%s`.",
+                local_state.value.story_id,
+                global_state.value.student.id,
+            )
+            return
+
+        component_state.set(component_state.value.__class__(**stage_json))
+
+        logger.info("Updated component state from database.")
+
+        return component_state.value
+
+    def delete_stage_state(
+        self,
+        global_state: Reactive[GlobalState],
+        local_state: Reactive[BaseLocalState],
+        component_state: Reactive[BaseState],
+    ):
+        r = self.request_session.delete(
+            f"{self.API_URL}/stage-state/{global_state.value.student.id}/"
+            f"{local_state.value.story_id}/{component_state.value.stage_id}"
+        )
+
+        if r.status_code != 200:
+            logger.error(
+                "Stage state for stage `%s`, story `%s` user `%s` did not exist in database.",
+                component_state.value.stage_id,
+                local_state.value.story_id,
+                global_state.value.student.id,
+            )
+            return
+
+        result = r.json()
+        if not result.get("success", False):
+            logger.error(
+                "Error deleting stage state for stage `%s`, story `%s` user `%s`.",
+                component_state.value.stage_id,
+                local_state.value.story_id,
+                global_state.value.student.id,
+            )
+            return
+
+    def get_story_state(
+        self, global_state: Reactive[GlobalState], local_state: Reactive[BaseLocalState]
+    ) -> BaseLocalState | None:
+        story_json = (
+            self.request_session.get(
+                f"{self.API_URL}/story-state/{global_state.value.student.id}/"
+                f"{local_state.value.story_id}"
+            )
+            .json()
+            .get("state", None)
+        )
+
+        if story_json is None:
+            logger.error(
+                "Failed to retrieve state for story `%s` for user `%s`.",
+                local_state.value.story_id,
+                global_state.value.student.id,
+            )
+            return
+
+        # global_state_json = story_json.get("app", {})
+        # global_state_json.pop("student")
+        # global_state.set(global_state.value.__class__(**global_state_json))
+
+        local_state_json = story_json.get("story", {})
+        local_state.set(local_state.value.__class__(**local_state_json))
+
+        logger.info("Updated local state from database.")
+
+        return local_state.value
+
+    def put_story_state(
+        self,
+        global_state: Reactive[GlobalState],
+        local_state: Reactive[BaseLocalState],
+    ):
+        logger.info("Serializing state into DB.")
+
+        state = {
+            "app": global_state.value.dict(),
+            "story": local_state.value.dict(
+                exclude={"measurements", "example_measurements"}
+            ),
+        }
+
+        r = self.request_session.put(
+            f"{self.API_URL}/story-state/{global_state.value.student.id}/{local_state.value.story_id}",
+            json=state,
+        )
+
+        if r.status_code != 200:
+            logger.error("Failed to write story state to database.")
 
     @staticmethod
     def clear_user(state: Reactive[GlobalState]):

--- a/src/cosmicds/state.py
+++ b/src/cosmicds/state.py
@@ -29,6 +29,12 @@ class Speech(BaseModel):
     voice: str = ""
 
 
+class BaseLocalState(BaseState):
+    debug_mode: bool = False
+    title: str
+    story_id: str
+
+
 class GlobalState(BaseState):
     drawer: bool = True
     speed_menu: bool = False


### PR DESCRIPTION
This PR allows us to reset the stage state for the current student/story/stage. To allow this, I've done the following:
* Create a "refresh button" component that reloads the current page and allows running some code pre-refresh. While Solara has a router that we can access, setting the path to the current URL has no effect, so this was the simplest way that I could think of to accomplish this
* Add a "reset stage state" button to the state editor component that uses the refresh button component and deletes the current stage state from the database
* Create a `BaseLocalState` class with a few common story state fields, so that we can reference them here
* To go along with this, I've moved the generic stage/story state manipulation endpoints here to the base package. I decided not to implement the `PUT` methods here, as these will generally involve things like ignoring fields that we can leave to a specific story.