### PR TITLE
Use jupyter install option for glue-plotly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     echo
     glue-core
     glue-jupyter
-    glue-plotly>=0.7.4
+    glue-plotly[jupyter]>=0.7.4
     httpx
     ipyvuetify
     numpy<2.0.0


### PR DESCRIPTION
The reason that we were getting an error about `ipyfilechooser` not being installed is that we should be using the `jupyter` install extras for `glue-plotly` (since `glue-jupyter` is the context that we're using the viewers in).