### PR TITLE
Scroll guidelines into view when mounted

### DIFF
--- a/src/cosmicds/vue_components/ScaffoldAlert.vue
+++ b/src/cosmicds/vue_components/ScaffoldAlert.vue
@@ -129,6 +129,12 @@
 <script>
 module.exports = {
   mounted() {
+
+    this.$el.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    });
+
     this.frElements = this.$el.getElementsByClassName("cds-free-response");
 
     this.updateFreeResponseList();


### PR DESCRIPTION
This PR updates the scaffold alert component to scroll the guideline into view when it's mounted.

Fixes https://github.com/cosmicds/hubbleds/issues/446.