### PR TITLE
Add margin to bottom of viewer layout

### DIFF
--- a/src/cosmicds/components/viewer_layout.py
+++ b/src/cosmicds/components/viewer_layout.py
@@ -38,7 +38,7 @@ def ViewerLayout(viewer):
             "width": "100%",
             "box-shadow": "0 3px 1px -2px rgba(0,0,0,.2),0 2px 2px 0 rgba(0,0,0,.14),0 1px 5px 0 rgba(0,0,0,.12) !important;",
         },
-        classes=["elevation-2"],
+        classes=["elevation-2 mb-4"],
     )
     with rv.Card(
         children=[layout]


### PR DESCRIPTION
Another tiny PR - this just adds a bit of margin below the viewer in the layout, so when two viewers are stacked on top of each other, there is a space between them.