### PR TITLE
Make selected reactive locally instead of getting passed in

### DIFF
--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -16,10 +16,10 @@ from typing import Iterable, List
 @solara.component
 def PercentageSelector(viewers: List[Viewer],
                        glue_data: List[Data],
-                       selected: Reactive[str | None],
                        bins: None | List[None | Iterable[None | Number]]=None,
                        **kwargs):
     
+    selected = solara.use_reactive(None)
     radio_color = "#1e90ff"
     options = [50, 68, 95]
     last_updated = selected.value 

--- a/src/cosmicds/components/statistics_selector.py
+++ b/src/cosmicds/components/statistics_selector.py
@@ -29,12 +29,12 @@ def find_statistic(stat: str, viewer: Viewer, data: Data, bins: Iterable[int | f
 def StatisticsSelector(viewers: List[PlotlyBaseView],
                        glue_data: List[Data],
                        units: List[str],
-                       selected: Reactive[str | None],
                        bins: None | List[None | Iterable[Number]]=None,
                        statistics: List[str]=["mean", "median", "mode"],
                        transform: Callable[[Number], Number] | None=None,
                        **kwargs):
 
+    selected = solara.use_reactive(None)
     color = kwargs.get("color", "#000000")
     bins = bins or [getattr(viewer.state, "bins", None) for viewer in viewers]
 


### PR DESCRIPTION
This goes with https://github.com/cosmicds/hubbleds/pull/493. 

We don't need to store students' selections on the percentage or statistics selectors on reload, and it was causing problems reloading the Stage 5 state, as noted [here](https://github.com/cosmicds/hubbleds/pull/487).

Instead of passing the values to the component from the Stage 5 page, we just use local reactive variables.