### PR TITLE
Allow executing code after student ID is loaded

### DIFF
--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -2,13 +2,14 @@ import datetime
 import os
 from warnings import filterwarnings
 from importlib.metadata import version
+from typing import Callable, Optional
 
 import solara
 from solara.alias import rv
 from solara.lab import theme, Ref
 from solara.server import settings
 from solara_enterprise import auth
-from solara import Reactive
+from solara import Callable, Reactive
 
 from .state import GLOBAL_STATE
 from .remote import BASE_API
@@ -30,6 +31,7 @@ def BaseLayout(
     children: list = [],
     story_name: str = "",
     story_title: str = "Cosmic Data Story",
+    on_student_info_loaded: Optional[Callable] = None,
 ):
     route_current, routes_current_level = solara.use_route()
     route_index = routes_current_level.index(route_current)
@@ -81,6 +83,9 @@ def BaseLayout(
         login_dialog = Login(active, class_code, update_db, debug_mode)
         active.set(True)
         return
+
+    if on_student_info_loaded is not None:
+        on_student_info_loaded()
 
     # Just for testing
     # Ref(GLOBAL_STATE.fields.student.id).set(0)

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -192,7 +192,6 @@ class BaseAPI:
             return
 
         global_state_json = story_json.get("app", {})
-        global_state_json.pop("student")
         global_state.set(global_state.value.__class__(**global_state_json))
 
         local_state_json = story_json.get("story", {})

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -171,7 +171,7 @@ class BaseAPI:
             )
             return
 
-    def get_story_state(
+    def get_app_story_states(
         self, global_state: Reactive[GlobalState], local_state: Reactive[BaseLocalState]
     ) -> BaseLocalState | None:
         story_json = (
@@ -191,9 +191,9 @@ class BaseAPI:
             )
             return
 
-        # global_state_json = story_json.get("app", {})
-        # global_state_json.pop("student")
-        # global_state.set(global_state.value.__class__(**global_state_json))
+        global_state_json = story_json.get("app", {})
+        global_state_json.pop("student")
+        global_state.set(global_state.value.__class__(**global_state_json))
 
         local_state_json = story_json.get("story", {})
         local_state.set(local_state.value.__class__(**local_state_json))


### PR DESCRIPTION
As mentioned in https://github.com/cosmicds/hubbleds/pull/502#issuecomment-2240339690, the app currently doesn't load the global state from the database. This hasn't mattered so far, since the only global state data that we've really been concerned with has been the student/class info (which does get loaded from the DB), but it matters for this PR.

This (along with a corresponding HubbleDS PR) attempts to fix this. The idea on the CosmicDS end is that we allow passing in a callable which can run after the student data has been loaded (which we can use story-side to do the relevant state loading, since we now know the ID).