### PR TITLE
Set default viewer height of 300

### DIFF
--- a/src/cosmicds/components/viewer_layout.py
+++ b/src/cosmicds/components/viewer_layout.py
@@ -24,7 +24,7 @@ def ToolBar(viewer):
 
 @solara.component
 def ViewerLayout(viewer):
-    make_figure_autoresize(viewer.figure_widget, 400)
+    make_figure_autoresize(viewer.figure_widget)
     # viewer.figure_widget.layout.height = 600
     layout = solara.Column(
         children=[

--- a/src/cosmicds/components/viewer_layout.py
+++ b/src/cosmicds/components/viewer_layout.py
@@ -1,4 +1,4 @@
-from cosmicds.utils import make_figure_autoresize
+from cosmicds.utils import make_figure_autoresize, DEFAULT_VIEWER_HEIGHT
 import solara
 import reacton.ipyvuetify as rv
 
@@ -23,8 +23,8 @@ def ToolBar(viewer):
     )
 
 @solara.component
-def ViewerLayout(viewer):
-    make_figure_autoresize(viewer.figure_widget)
+def ViewerLayout(viewer, viewer_height=DEFAULT_VIEWER_HEIGHT):
+    make_figure_autoresize(viewer.figure_widget, viewer_height)
     # viewer.figure_widget.layout.height = 600
     layout = solara.Column(
         children=[

--- a/src/cosmicds/utils.py
+++ b/src/cosmicds/utils.py
@@ -45,6 +45,7 @@ API_URL = "https://api.cosmicds.cfa.harvard.edu"
 
 CDS_IMAGE_BASE_URL = "https://cosmicds.github.io/cds-website/cosmicds_images/mean_median_mode"
 
+DEFAULT_VIEWER_HEIGHT = 300
 
 def get_session_id() -> str:
     """Returns the session id, which is stored using a browser cookie."""
@@ -445,7 +446,7 @@ def empty_data_from_model_class(cls: Type[BaseModel], label: str | None=None):
     return Data(**data_dict)
 
 
-def make_figure_autoresize(figure, height=400):
+def make_figure_autoresize(figure, height=DEFAULT_VIEWER_HEIGHT):
     # The auto-sizing in the Plotly widget only works if the height
     # and width are undefined. First, unset the height and width,
     # then enable auto-sizing.

--- a/src/cosmicds/viewers/state.py
+++ b/src/cosmicds/viewers/state.py
@@ -7,7 +7,7 @@ from glue.viewers.scatter.state import ScatterViewerState
 from glue_plotly.viewers.histogram.state import PlotlyHistogramViewerState
 from numpy import linspace, inf, isfinite, isnan, spacing
 
-from cosmicds.utils import frexp10
+from cosmicds.utils import frexp10, DEFAULT_VIEWER_HEIGHT
 
 
 def cds_viewer_state(state_class):
@@ -19,7 +19,7 @@ def cds_viewer_state(state_class):
         xtick_values = CallbackProperty([])
         ytick_values = CallbackProperty([])
 
-        viewer_height = CallbackProperty(400)
+        viewer_height = CallbackProperty(DEFAULT_VIEWER_HEIGHT)
         viewer_width = CallbackProperty(400)
 
         @staticmethod


### PR DESCRIPTION
In the voila version, most of the scatter and histogram viewers were 300px. In this version, we've been using 400px, which is too tall in the case where 2 viewers are stacked on top of each other.

(This only impacts the viewers that make use of the ViewerLayout, which in the hubbleds includes Hubble scatter viewers & histogram viewers in Stages 4, 5, and 6. I haven't changed any of the viewers in Stages 1 & 3).