### PR TITLE
Fix global state loading

### DIFF
--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -10,7 +10,7 @@ from solara.server import settings
 from solara_enterprise import auth
 from solara import Reactive
 
-from .state import GLOBAL_STATE
+from .state import GLOBAL_STATE, BaseLocalState
 from .remote import BASE_API
 from cosmicds import load_custom_vue_components
 from cosmicds.utils import get_session_id
@@ -27,6 +27,7 @@ logger = setup_logger("LAYOUT")
 
 @solara.component
 def BaseLayout(
+    local_state: Reactive[BaseLocalState],
     children: list = [],
     story_name: str = "",
     story_title: str = "Cosmic Data Story",
@@ -165,8 +166,8 @@ def BaseLayout(
             )
 
             with rv.Chip(class_="ma-2 piggy-chip"):                    
-                    # check that this doesn't make solara render the whole app. if it does, move the chip into its own component.
-                solara.Text(f"{GLOBAL_STATE.value.piggybank_total} Points")
+                # check that this doesn't make solara render the whole app. if it does, move the chip into its own component.
+                solara.Text(f"{local_state.value.piggybank_total} Points")
 
                 rv.Icon(class_="ml-2",
                     children=["mdi-piggy-bank"],

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -2,6 +2,7 @@ import datetime
 import os
 from warnings import filterwarnings
 from importlib.metadata import version
+from typing import Optional
 
 import solara
 from solara.alias import rv
@@ -27,7 +28,7 @@ logger = setup_logger("LAYOUT")
 
 @solara.component
 def BaseLayout(
-    local_state: Reactive[BaseLocalState],
+    local_state: Optional[Reactive[BaseLocalState]] = None,
     children: list = [],
     story_name: str = "",
     story_title: str = "Cosmic Data Story",
@@ -166,8 +167,9 @@ def BaseLayout(
             )
 
             with rv.Chip(class_="ma-2 piggy-chip"):                    
-                # check that this doesn't make solara render the whole app. if it does, move the chip into its own component.
-                solara.Text(f"{local_state.value.piggybank_total} Points")
+                if local_state:
+                    # check that this doesn't make solara render the whole app. if it does, move the chip into its own component.
+                    solara.Text(f"{local_state.value.piggybank_total} Points")
 
                 rv.Icon(class_="ml-2",
                     children=["mdi-piggy-bank"],

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -2,14 +2,13 @@ import datetime
 import os
 from warnings import filterwarnings
 from importlib.metadata import version
-from typing import Callable, Optional
 
 import solara
 from solara.alias import rv
 from solara.lab import theme, Ref
 from solara.server import settings
 from solara_enterprise import auth
-from solara import Callable, Reactive
+from solara import Reactive
 
 from .state import GLOBAL_STATE
 from .remote import BASE_API
@@ -31,7 +30,6 @@ def BaseLayout(
     children: list = [],
     story_name: str = "",
     story_title: str = "Cosmic Data Story",
-    on_student_info_loaded: Optional[Callable] = None,
 ):
     route_current, routes_current_level = solara.use_route()
     route_index = routes_current_level.index(route_current)
@@ -83,9 +81,6 @@ def BaseLayout(
         login_dialog = Login(active, class_code, update_db, debug_mode)
         active.set(True)
         return
-
-    if on_student_info_loaded is not None:
-        on_student_info_loaded()
 
     # Just for testing
     # Ref(GLOBAL_STATE.fields.student.id).set(0)

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -192,6 +192,7 @@ class BaseAPI:
             return
 
         global_state_json = story_json.get("app", {})
+        global_state_json.pop("student")
         global_state.set(global_state.value.__class__(**global_state_json))
 
         local_state_json = story_json.get("story", {})

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -171,7 +171,7 @@ class BaseAPI:
             )
             return
 
-    def get_app_story_states(
+    def get_story_state(
         self, global_state: Reactive[GlobalState], local_state: Reactive[BaseLocalState]
     ) -> BaseLocalState | None:
         story_json = (
@@ -191,9 +191,9 @@ class BaseAPI:
             )
             return
 
-        global_state_json = story_json.get("app", {})
-        global_state_json.pop("student")
-        global_state.set(global_state.value.__class__(**global_state_json))
+        # global_state_json = story_json.get("app", {})
+        # global_state_json.pop("student")
+        # global_state.set(global_state.value.__class__(**global_state_json))
 
         local_state_json = story_json.get("story", {})
         local_state.set(local_state.value.__class__(**local_state_json))

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -171,7 +171,7 @@ class BaseAPI:
             )
             return
 
-    def get_story_state(
+    def get_app_story_states(
         self, global_state: Reactive[GlobalState], local_state: Reactive[BaseLocalState]
     ) -> BaseLocalState | None:
         story_json = (
@@ -191,11 +191,11 @@ class BaseAPI:
             )
             return
 
-        # global_state_json = story_json.get("app", {})
-        # global_state_json.pop("student")
-        # global_state.set(global_state.value.__class__(**global_state_json))
+        global_state_json = story_json.get("app", {})
+        global_state.set(global_state.value.__class__(**global_state_json))
 
         local_state_json = story_json.get("story", {})
+        logger.info(local_state_json)
         local_state.set(local_state.value.__class__(**local_state_json))
 
         logger.info("Updated local state from database.")

--- a/src/cosmicds/state.py
+++ b/src/cosmicds/state.py
@@ -34,6 +34,7 @@ class BaseLocalState(BaseState):
     debug_mode: bool = False
     title: str
     story_id: str
+    piggybank_total: int = 0
 
 
 class GlobalState(BaseState):
@@ -46,7 +47,6 @@ class GlobalState(BaseState):
     show_team_interface: bool = False
     allow_advancing: bool = True
     speech: Speech = Speech()
-    piggybank_total: int = 0
 
     @cached_property
     def _glue_app(self) -> JupyterApplication:


### PR DESCRIPTION
This PR is intended to help with https://github.com/cosmicds/hubbleds/issues/515. Something about that way that I set things up in #316/https://github.com/cosmicds/hubbleds/pull/513 was causing endless re-rendering on multiple stages. This PR undoes some of #316. It also moves the piggybank total into the story state (which I think makes more sense) and allows passing an (optional) story state into the base layout.