### PR TITLE
Add gaps between histogram bars by default

### DIFF
--- a/src/cosmicds/viewers/state.py
+++ b/src/cosmicds/viewers/state.py
@@ -175,6 +175,9 @@ class CDSScatterViewerState(ScatterViewerState):
 
 class CDSHistogramViewerState(PlotlyHistogramViewerState):
 
+    gaps = CallbackProperty(True)
+    gap_fraction = CallbackProperty(0.15)
+
     def _reset_x_limits(self):
         bounds = []
         for layer in filter(lambda layer: layer.visible, self.layers):


### PR DESCRIPTION
This PR updates the defaults for our histogram viewer states to resolve https://github.com/cosmicds/hubbleds/issues/556. I assume we'll generally want gaps between bars, so I made it the default here rather than at the Hubble level.

@patudom Let me know if we want to adjust the gap sizing - the gap fraction indicates what percentage of the plot's horizontal space is taken up by the gaps (so `0.5` would mean that the bars and gaps are equally sized, for example).