### PR TITLE
Add API method for updating class size

### DIFF
--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -51,6 +51,15 @@ class BaseAPI:
         r = self.request_session.get(f"{self.API_URL}/student/{self.hashed_user}")
         return r.json()["student"] is not None
 
+    # TODO: Feels like there should be a more straightforward way to get this info
+    # on the backend
+    def update_class_size(self, story_name: str, state: Reactive[GlobalState]):
+        student_id = state.value.student.id
+        class_json = self.request_session.get(
+            f"{self.API_URL}/class-for-student-story/{student_id}/{story_name}"
+        ).json()
+        Ref(state.fields.classroom.size).set(class_json["size"])
+
     def load_user_info(self, story_name: str, state: Reactive[GlobalState]):
         student_json = self.request_session.get(
             f"{self.API_URL}/student/{self.hashed_user}"

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -51,14 +51,12 @@ class BaseAPI:
         r = self.request_session.get(f"{self.API_URL}/student/{self.hashed_user}")
         return r.json()["student"] is not None
 
-    # TODO: Feels like there should be a more straightforward way to get this info
-    # on the backend
-    def update_class_size(self, story_name: str, state: Reactive[GlobalState]):
-        student_id = state.value.student.id
-        class_json = self.request_session.get(
-            f"{self.API_URL}/class-for-student-story/{student_id}/{story_name}"
+    def update_class_size(self, state: Reactive[GlobalState]):
+        class_id = state.value.classroom.class_info["id"]
+        size_json = self.request_session.get(
+            f"{self.API_URL}/classes/size/{class_id}"
         ).json()
-        Ref(state.fields.classroom.size).set(class_json["size"])
+        Ref(state.fields.classroom.size).set(size_json["size"])
 
     def load_user_info(self, story_name: str, state: Reactive[GlobalState]):
         student_json = self.request_session.get(


### PR DESCRIPTION
This PR adds a method to the base API for updating the class size. It feels like there should be a more straightforward way to do this from the backend endpoints, but this works for now.