### PR TITLE
Display percentage and statistic info on graph

### DIFF
--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -28,6 +28,7 @@ def PercentageSelector(viewers: List[Viewer],
     bins = bins or [getattr(viewer.state, "bins", None) for viewer in viewers]
     units = kwargs.get("units", [])
     deselected_color = "#a9a9a9"
+    annotations = []
 
     # When this component is 
     subsets = []
@@ -111,6 +112,7 @@ def PercentageSelector(viewers: List[Viewer],
         if option is None:
             states = []
             for (index, viewer) in enumerate(viewers):
+                viewer.figure.layout.annotations = []
                 if layers[index] is not None:
                     layers[index].state.color = original_colors[index]
                     # viewer_layouts[index].set_subtitle(None)
@@ -121,6 +123,7 @@ def PercentageSelector(viewers: List[Viewer],
 
         states = []
         for index, (viewer, viewer_bins) in enumerate(zip(viewers, bins)):
+            viewer.figure.layout.annotations = []
             component_id = viewer.state.x_att
             data = glue_data[index][component_id]
             layer = layers[index]
@@ -181,7 +184,9 @@ def PercentageSelector(viewers: List[Viewer],
             else:
                 unit_str = ""
             label_text = f"{option}% range: {bottom_str} \u2013 {top_str}{unit_str}"
-            # self.viewer_layouts[index].set_subtitle(label_text)
+            viewer.figure.add_annotation(text=label_text, xref="paper", yref="paper",
+                                         x=0.5, y=1.2, showarrow=False)
+            
 
         _update_subsets(states)
 

--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -28,7 +28,6 @@ def PercentageSelector(viewers: List[Viewer],
     bins = bins or [getattr(viewer.state, "bins", None) for viewer in viewers]
     units = kwargs.get("units", [])
     deselected_color = "#a9a9a9"
-    annotations = []
 
     # When this component is 
     subsets = []

--- a/src/cosmicds/components/statistics_selector.py
+++ b/src/cosmicds/components/statistics_selector.py
@@ -60,7 +60,6 @@ def StatisticsSelector(viewers: List[PlotlyBaseView],
         "mean": "The mean is the average of all values in the dataset. The average is calculated by adding all the values together and dividing by the number of values. In this example, the mean of the distribution is 14.",
         "median": "The median is the middle of the dataset. Fifty percent of the data has values greater than the median and fifty percent has values less than or equal to the median. In this example, the median of the distribution is 15.",
         "mode": "The mode is the most commonly measured value or range of values in a set of data and appears as the tallest bar in a histogram. In this example, the mode of the distribution is 16.",
-
     }
     help_images = {
         "mean": f"{image_location}/mean.png",
@@ -132,7 +131,6 @@ def StatisticsSelector(viewers: List[PlotlyBaseView],
             line_ids.append(viewer_line_ids)
 
         return stat
-
 
     def _update_selected(stat: str | None, value: bool):
         nonlocal last_updated

--- a/src/cosmicds/components/statistics_selector.py
+++ b/src/cosmicds/components/statistics_selector.py
@@ -38,8 +38,8 @@ def labeled_vertical_line(x: float, y_min: float, y_max: float, color: str, labe
         mode="text+lines",
         line=dict(color=color),
         name=label,
-        text=['', text, ''],
-        textposition="top right"
+        text=['', f'  {text}', ''],
+        textposition="top right",
     )
 
 


### PR DESCRIPTION
This PR resolves https://github.com/cosmicds/hubbleds/issues/512 by displaying the relevant info on the graph for viewers connected to the statistics/percentage selectors. For the statistics selector, we add a text label to the line(s) drawn that indicate the statistic, value, and unit. For the percentage selector, we add text above the viewer's plot area that gives the percentage and the range of values.