### PR TITLE
Speech synthesizer component

### DIFF
--- a/src/cosmicds/components/scaffold_alert.py
+++ b/src/cosmicds/components/scaffold_alert.py
@@ -1,7 +1,8 @@
+from cosmicds.state import Speech
 import solara
 import inspect
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 
 
 def ScaffoldAlert(
@@ -17,6 +18,7 @@ def ScaffoldAlert(
     fr_listener=None,
     state_view: dict = None,
     event_force_transition: Callable = lambda *args: None,
+    speech_options: Optional[Speech] = None,
     **kwargs
 ):
     """
@@ -105,6 +107,7 @@ def ScaffoldAlert(
         frListener,
         state_view,
         event_force_transition,
+        speech,
     ):
         pass
 
@@ -120,6 +123,7 @@ def ScaffoldAlert(
 
     _ScaffoldAlert = solara.component_vue(vue_path)(_ScaffoldAlert)
 
+    speech = speech_options.model_dump() if speech_options is not None else None
     return _ScaffoldAlert(
         event_back_callback=event_back_callback,
         event_next_callback=event_next_callback,
@@ -131,5 +135,6 @@ def ScaffoldAlert(
         frListener=fr_listener,
         state_view=state_view,
         event_force_transition=event_force_transition,
+        speech=speech,
         **kwargs
     )

--- a/src/cosmicds/components/scaffold_alert.py
+++ b/src/cosmicds/components/scaffold_alert.py
@@ -18,7 +18,7 @@ def ScaffoldAlert(
     fr_listener=None,
     state_view: dict = None,
     event_force_transition: Callable = lambda *args: None,
-    speech_options: Optional[Speech] = None,
+    speech: Optional[Speech] = None,
     **kwargs
 ):
     """
@@ -123,7 +123,7 @@ def ScaffoldAlert(
 
     _ScaffoldAlert = solara.component_vue(vue_path)(_ScaffoldAlert)
 
-    speech = speech_options.model_dump() if speech_options is not None else None
+    speech_dict = speech.model_dump() if speech is not None else None
     return _ScaffoldAlert(
         event_back_callback=event_back_callback,
         event_next_callback=event_next_callback,
@@ -135,6 +135,6 @@ def ScaffoldAlert(
         frListener=fr_listener,
         state_view=state_view,
         event_force_transition=event_force_transition,
-        speech=speech,
+        speech=speech_dict,
         **kwargs
     )

--- a/src/cosmicds/components/speech_settings/SpeechSettings.vue
+++ b/src/cosmicds/components/speech_settings/SpeechSettings.vue
@@ -1,0 +1,140 @@
+<template>
+  <v-card min-width="300">
+    <v-list>
+      <v-list-item>
+        <v-list-item-content>
+          <v-list-item-title>Speech Reader</v-list-item-title>
+          <v-list-item-subtitle>Adjust speech settings</v-list-item-subtitle>
+        </v-list-item-content>
+      </v-list-item>
+      <v-divider></v-divider>
+      <v-list-item>
+        <v-switch
+          v-model="autoread"
+          label="Automatically read text"
+        ></v-switch>
+      </v-list-item>
+      <v-list-item>
+        <v-slider
+          v-model="rate"
+          :label="rate.toFixed(1)"
+          color="blue"
+          :min="0.5"
+          :max="2"
+          :step="0.1"
+          :thumb-label="false"
+        >
+        <template v-slot:prepend>
+          <v-tooltip left>
+            <template v-slot:activator="{ on }">
+              <v-icon
+                v-on="on"
+                @click="rate = 1"
+              >
+                mdi-speedometer
+              </v-icon>
+            </template>
+            Reset rate
+          </v-tooltip>
+        </template>
+        </v-slider>
+      </v-list-item>
+      <v-list-item>
+        <v-slider
+          v-model="pitch"
+          :label="pitch.toFixed(1)"
+          color="blue"
+          :min="0.1"
+          :max="2"
+          :step="0.1"
+          :thumb-label="false"
+        >
+        <template v-slot:prepend>
+          <v-tooltip left>
+            <template v-slot:activator="{ on }">
+              <v-icon
+                v-on="on"
+                @click="pitch = 1"
+              >
+                mdi-music-note
+              </v-icon>
+            </template>
+            Reset pitch
+          </v-tooltip>
+        </template>
+        </v-slider>
+      </v-list-item>
+      <v-list-item>
+        <v-select
+          v-model="voice"
+          :items="voices"
+          :item-text="voice => `${voice.name} (${voice.lang})`"
+          item-value="name"
+          label="Select voice"
+        ></v-select>
+      </v-list-item>
+    </v-list>
+  </v-card>
+</template>
+
+<script>
+module.exports = {
+  props: {
+    initialState: {
+      type: Object,
+      default: null,
+    }
+  },
+  created() {
+    window.speechSynthesis.onvoiceschanged = (_event) => {
+      this.updateVoiceList();
+    };
+    this.updateVoiceList();
+
+    this.autoread = this.initialState?.autoread ?? false;
+    this.pitch = this.initialState?.pitch ?? 1;
+    this.rate = this.initialState?.rate ?? 1;
+  },
+  data() {
+    return {
+      autoread: false,
+      pitch: 1,
+      rate: 1,
+      voiceURIs: [
+        'Google US English',
+        'urn:moz-tts:speechd:English%20(America)?en',
+        'Alex',
+        'Tessa',
+        'urn:moz-tts:osx:com.apple.speech.synthesis.voice.Alex',
+        'urn:moz-tts:osx:com.apple.speech.synthesis.voice.tessa',
+        'com.apple.speech.synthesis.voice.Alex',
+        'com.apple.speech.synthesis.voice.tessa',
+        'Microsoft Zira - English (United States)',
+        'Microsoft Aria Online (Natural) - English (United States)',
+        'urn:moz-tts:sapi:Microsoft Zira - English (United States)?en-US'
+      ],
+      voices: [],
+      voice: null
+    }
+  },
+  methods: {
+    updateVoiceList() {
+      this.voices = window.speechSynthesis.getVoices().filter(voice => this.voiceURIs.includes(voice.voiceURI));
+    }
+  },
+  watch: {
+    autoread(read) {
+      this.autoread_changed(read);
+    },
+    pitch(value) {
+      this.pitch_changed(value);
+    },
+    rate(value) {
+      this.rate_changed(value);
+    },
+    voice(newVoice) {
+      this.voice_changed(newVoice.voiceURI);
+    }
+  }
+}
+</script>

--- a/src/cosmicds/components/speech_settings/__init__.py
+++ b/src/cosmicds/components/speech_settings/__init__.py
@@ -1,0 +1,1 @@
+from .speech_settings import SpeechSettings

--- a/src/cosmicds/components/speech_settings/speech_settings.py
+++ b/src/cosmicds/components/speech_settings/speech_settings.py
@@ -1,0 +1,13 @@
+import solara
+from typing import Optional, Callable
+
+
+@solara.component_vue("SpeechSettings.vue")
+def SpeechSettings(
+    initial_state: dict,
+    event_autoread_changed: Optional[Callable[[bool], None]] = None,
+    event_pitch_changed: Optional[Callable[[float], None]] = None,
+    event_rate_changed: Optional[Callable[[float], None]] = None,
+    event_voice_changed: Optional[Callable[[str], None]] = None,
+):
+    pass

--- a/src/cosmicds/components/speech_synthesizer.py
+++ b/src/cosmicds/components/speech_synthesizer.py
@@ -1,11 +1,10 @@
 import os
 import solara
+from typing import Optional
+
 
 @solara.component_vue(os.path.join("..", "vue_components", "SpeechSynthesizer.vue"))
 def SpeechSynthesizer(
-    autoread: bool,
-    voice: str,
-    pitch: float,
-    rate: float,
+    options: Optional[dict] = None,
 ):
     pass

--- a/src/cosmicds/components/speech_synthesizer.py
+++ b/src/cosmicds/components/speech_synthesizer.py
@@ -1,0 +1,11 @@
+import os
+import solara
+
+@solara.component_vue(os.path.join("..", "vue_components", "SpeechSynthesizer.vue"))
+def SpeechSynthesizer(
+    autoread: bool,
+    voice: str,
+    pitch: float,
+    rate: float,
+):
+    pass

--- a/src/cosmicds/state.py
+++ b/src/cosmicds/state.py
@@ -24,14 +24,14 @@ class Classroom(BaseModel):
 
 
 class Speech(BaseModel):
-    pitch: int = 0
-    rate: int = 0
+    pitch: float = 1.0
+    rate: float = 1.0
     autoread: bool = False
-    voice: str = ""
+    voice: str | None = None
 
 
 class BaseLocalState(BaseState):
-    debug_mode: bool = False
+    debug_mode: bool = True
     title: str
     story_id: str
     piggybank_total: int = 0

--- a/src/cosmicds/vue_components/ScaffoldAlert.vue
+++ b/src/cosmicds/vue_components/ScaffoldAlert.vue
@@ -40,13 +40,23 @@
           v-else
           class="mx-2 shrink"
         >
-<!--          <speech-synthesizer/>-->
+          <speech-synthesizer
+            :pitch="speech?.pitch ?? 1"
+            :rate="speech?.rate ?? 1"
+            :autoread="speech?.autoread ?? false"
+            :voice="speech?.voice"
+          />
         </v-col>
         <v-col
           v-if="allowBack"
           class="mx-2 shrink"
         >
-<!--          <speech-synthesizer/>-->
+          <speech-synthesizer
+            :pitch="speech?.pitch ?? 1"
+            :rate="speech?.rate ?? 1"
+            :autoread="speech?.autoread ?? false"
+            :voice="speech?.voice"
+          />
         </v-col>
         <v-col
           v-else
@@ -191,6 +201,10 @@ module.exports = {
       type: Boolean,
       default: true
     },
+    speech: {
+      type: Object,
+      default: null
+    }
   },
   data() {
     return {

--- a/src/cosmicds/vue_components/ScaffoldAlert.vue
+++ b/src/cosmicds/vue_components/ScaffoldAlert.vue
@@ -41,10 +41,7 @@
           class="mx-2 shrink"
         >
           <speech-synthesizer
-            :pitch="speech?.pitch ?? 1"
-            :rate="speech?.rate ?? 1"
-            :autoread="speech?.autoread ?? false"
-            :voice="speech?.voice"
+            :options="speech"
           />
         </v-col>
         <v-col
@@ -52,10 +49,7 @@
           class="mx-2 shrink"
         >
           <speech-synthesizer
-            :pitch="speech?.pitch ?? 1"
-            :rate="speech?.rate ?? 1"
-            :autoread="speech?.autoread ?? false"
-            :voice="speech?.voice"
+            :options="speech"
           />
         </v-col>
         <v-col
@@ -141,6 +135,8 @@
 module.exports = {
   mounted() {
 
+    console.log(this.speech);
+
     if (this.scrollOnMount) {
       this.$el.scrollIntoView({
         behavior: 'smooth',
@@ -211,7 +207,7 @@ module.exports = {
       frObserver: null,
       freeResponses: [],
       disableNext: false,
-      frListener: null
+      frListener: null,
     }
   },
   computed: {

--- a/src/cosmicds/vue_components/SpeechSynthesizer.vue
+++ b/src/cosmicds/vue_components/SpeechSynthesizer.vue
@@ -1,0 +1,379 @@
+<template>
+  <span>
+    <slot>
+      <v-btn
+        icon
+      >
+        <v-icon
+          @click="(_event) => speak()"
+        >
+          {{ speaking ? 'mdi-stop' : 'mdi-voice' }}
+        </v-icon>
+      </v-btn>
+    </slot>
+  </span>
+</template>
+
+<script>
+module.exports = {
+  props: {
+    autoread: {
+      type: Boolean,
+      default: true,
+    },
+    voice: {
+      type: String,
+      default: null,
+    },
+    pitch: {
+      type: Number,
+      default: 1,
+    },
+    rate: {
+      type: Number,
+      default: 1,
+    },
+    selectors: {
+      type: Array,
+      default: () => ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', ':not(mjx-assistive-mml) > mjx-container']
+    },
+    stopOnClose: {
+      type: Boolean,
+      default: true
+    },
+    root: {
+      type: [Object, Function],
+      default: null
+    },
+    elementFilter: {
+      type: [Function],
+      default: null
+    },
+    autospeakOnChange: {
+      type: [Boolean, Number],
+      default: null
+    },
+    speakFlag: {
+      type: Boolean,
+      default: false
+    },
+  },
+  data() {
+    return {
+      utteranceSpeaking: false,
+      speakingTimeoutID: null,
+      intervalID: 0,
+      rootElement: null,
+      iconNameMap: {
+        'cached': 'reset'
+      },
+      defaultVoicesURIs: [
+        "Microsoft Aria Online (Natural) - English (United States)",
+        "Google US English",
+        "com.apple.speech.synthesis.voice.Alex"
+      ],
+      defaultVoice: null,
+      utterances: new Set(),
+      findingRoot: false
+    };
+  },
+  mounted() {
+    this.intersectionCallback = (entries, _observer) => {
+
+      // The IntersectionObserver is called once as soon as it's instantiated
+      // We don't want that!
+      // so here's a workaround
+      // This is set in the rootElement watcher, where the observer is created
+      // if (this.findingRoot) {
+      //   this.findingRoot = false;
+      //   return;
+      // }
+
+      entries.forEach((entry) => {
+        if (entry.target !== this.rootElement) { return; }
+        if (!entry.isIntersecting) {
+          this.stopThisSpeaking();
+        } else if (!this.speaking && entry.isIntersecting && this.getSpeechOptions().autoread > 0) {
+          this.triggerAutospeak(true);
+        }
+      });
+    };
+    this.$nextTick(() => {
+      this.findRootElement();
+    });
+  },
+  destroyed() {
+    if (this.stopOnClose && this.isSpeaking()) {
+      clearInterval(this.intervalID);
+      this.speaking = false;
+      window.speechSynthesis.cancel();
+    }
+  },
+  computed: {
+    speaking: {
+      get() {
+        return this.utteranceSpeaking;
+      },
+      set(value) {
+        if (this.speakingTimeoutID) {
+          clearTimeout(this.speakingTimeoutID);
+        }
+        this.speakingTimeoutID = setTimeout(() => {
+          this.utteranceSpeaking = value;
+        }, 300);
+      }
+    }
+  },
+  methods: {
+
+    triggerAutospeak(forceSpeak=true) {
+      if (this.autospeak) {
+        this.$nextTick(() => this.speak(forceSpeak));
+      }
+    },
+
+    elementText(element) {
+
+      // Replace any MDI icons with text representing their name
+      const clone = element.cloneNode(true);
+      const mdiPrefix = "mdi-";
+      const icons = clone.querySelectorAll(`[class*='${mdiPrefix}']`);
+      icons.forEach(icon => {
+        const classes = [...icon.classList].filter(cls => cls.startsWith(mdiPrefix));
+        if (classes.length === 0) {
+          icon.remove();
+        } else {
+          const txt = document.createElement("text");
+          const cls = classes[0];
+          let iconName = cls.slice(mdiPrefix.length);
+          txt.textContent = this.iconNameMap[iconName] ?? iconName.replace("-", " ");
+          icon.parentNode?.replaceChild(txt, icon);
+        }
+      });
+
+      // Replace any MathJax with its semantic speech text
+      if (clone.tagName === "mjx-container") {
+        const speechText = clone.getAttribute("aria-label");
+        if (speechText) {
+          const txt = document.createElement("text");
+          txt.textContent = speechText;
+          clone.parentNode?.replaceChild(txt, clone);
+        } else {
+          clone.remove();
+        }
+      }
+
+      return clone.textContent.trim();
+
+    },
+    makeUtterance(text, options) {
+      const utterance = new SpeechSynthesisUtterance(text);
+
+      options = options || this.getSpeechOptions();
+      Object.keys(options).forEach(key => {
+        utterance[key] = options[key];
+      });
+      this.transformRate(utterance);
+
+      // The interval is to work around this issue:
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=679437
+      //
+      // We could just use one interval for the entire block of text items
+      // but the pause-resume is sometimes slightly audible, so better to minimize that.
+      // Note that the pause-resume won't happen if the text takes longer than 14 seconds to say
+      const synth = window.speechSynthesis;
+      utterance.onstart = (_event) => {
+        this.intervalID = setInterval(() => {
+          synth.pause();
+          synth.resume();
+        }, 14000);
+        synth.utterance = utterance;
+        this.speaking = true;
+      }
+      utterance.onend = (_event) => {
+        synth.utterance = null;
+        this.speaking = false;
+        this.utterances.delete(utterance);
+        clearInterval(this.intervalID);
+      }
+
+      return utterance;
+    },
+    findRootElement() {
+      if (this.root instanceof Element) {
+        this.rootElement = this.root;
+      } else if (this.root instanceof Function) {
+        this.rootElement = this.root();
+      } else {
+        this.rootElement = this.$parent.$el;
+      }
+    },
+    getSpeechOptions() {
+      const voiceName = this.voice;
+      this.defaultVoice = this.defaultVoice || window.speechSynthesis.getVoices().find(voice => this.defaultVoicesURIs.includes(voice.voiceURI));
+      const voice = window.speechSynthesis.getVoices().find(voice => voice.name == voiceName) || this.defaultVoice;
+      const options = {
+        autoread: this.autoread,
+        pitch: this.pitch,
+        rate: this.rate,
+      };
+      if (voice) {
+        options.voice = voice;
+      }
+      return options;
+    },
+    // Taken from https://www.geeksforgeeks.org/how-to-check-if-an-element-is-visible-in-dom/
+    // TODO: Is there a better way to check?
+    //
+    // Note that element.checkVisibility() doesn't work on Safari:
+    // https://caniuse.com/mdn-api_element_checkvisibility
+    isElementVisible(element) {
+      if (element.checkVisibility) {
+        return element.checkVisibility();
+      }
+      return element.offsetWidth || 
+             element.offsetHeight || 
+             element.getClientRects().length;
+    },
+    getSpeechItems(selectors=this.selectors) {
+      if (this.rootElement === null) {
+        this.findRootElement();
+      }
+      const selectedElements = this.rootElement.querySelectorAll(selectors.join(","));
+      let elements = [].concat(...selectedElements).filter(this.isElementVisible);
+      if (this.elementFilter) {
+        elements = elements.filter(this.elementFilter);
+      }
+      const items = elements.map(element => this.elementText(element)).filter(text => text.length > 0);
+      return items;
+    },
+
+    speakForSelectors(selectors) {
+      this.speak(true, selectors)
+    },
+
+    speak(forceSpeak=false, selectors=this.selectors) {
+      const wasSpeaking = this.isSpeaking();
+      this.cancelSpeech();
+      if (wasSpeaking && !forceSpeak) {
+        return;
+      }
+
+      // We say each speech item as its own utterance
+      // This gives a nice pause between paragraphs
+      this.speaking = true;
+      const items = this.getSpeechItems(selectors);
+      const options = this.getSpeechOptions();
+      const utterances = items.map(item => this.makeUtterance(item, options));
+      this.utterances = new Set(utterances);
+
+      // const lastUtterance = utterances[utterances.length - 1];
+      // const lastOnEnd = lastUtterance.onend;
+      // lastUtterance.onend = (event) => {
+      //   lastOnEnd(event);
+      //   this.speaking = false;
+      // }
+      
+      //utterances.forEach((utterance) => synth.speak(utterance));
+      utterances.forEach(utterance => {
+        window.speechSynthesis.speak(utterance);
+      });
+    },
+
+    stopThisSpeaking() {
+      this.speaking = false;
+      if (this.isSpeaking()) {
+        this.cancelSpeech();
+      }
+    },
+
+    cancelSpeech() {
+      window.speechSynthesis.utterance = null;
+      window.speechSynthesis.cancel();
+      this.utterances.clear();
+      clearInterval(this.intervalID);
+      this.speaking = false;
+    },
+
+    // I made this a method rather than a computed since synth.speaking is not reactive
+    isSpeaking() {
+      const synth = window.speechSynthesis;
+      return synth.speaking && this.utterances.has(synth.utterance);
+    },
+
+    detectBrowser() {
+      let userAgent = navigator.userAgent;
+      let browserName;
+
+      if (userAgent.match(/chrome|chromium|crios/i)) {
+        browserName = "chrome";
+      } else if (userAgent.match(/firefox|fxios/i)) {
+        browserName = "firefox";
+      } else if (userAgent.match(/safari/i)) {
+        browserName = "safari";
+      } else if (userAgent.match(/opr\//i)) {
+        browserName = "opera";
+      } else if (userAgent.match(/edg/i)) {
+        browserName = "edge";
+      } else {
+        browserName = null;
+      }
+
+      return browserName
+    },
+
+    transformRate(utterance) {
+      if (!utterance.voice) {
+        return;
+      }
+      const uri = utterance.voice.voiceURI;
+      let rate = utterance.rate;
+      if (uri === "Google US English") {
+        rate = Math.sqrt(2 * utterance.rate - 2 / 3) - 1 / 5;
+      } else if (uri === 'Microsoft Zira - English (United States)') {
+        const browser = this.detectBrowser();
+        if (browser === 'chrome') {
+          rate = Math.pow(utterance.rate, 2.5);
+        } else if (browser === 'edge') {
+          rate = 1.5 * (utterance.rate - 0.25);
+        }
+      }
+      rate = Math.max(rate, 0.5);
+      utterance.rate = rate;
+    }
+
+  },
+
+  watch: {
+    // For the v-dialog slideshows, using nextTick (again, since triggerAutospeak uses it)
+    // didn't seem to be enough - the DOM changes hadn't finished propagating yet.
+    // But this does the trick, and I don't notice it at all
+    autospeakOnChange(_item) {
+      setTimeout(() => {{
+        this.triggerAutospeak();
+      }}, 100);
+    },
+
+    speakFlag(flag) {
+      if (flag) {
+        setTimeout(() => {{
+          this.triggerAutospeak();
+        }}, 100);
+      } else {
+        if (this.isSpeaking()) {
+          window.speechSynthesis.cancel();
+          this.speaking = false;
+        }
+      }
+    },
+    rootElement(newRoot, oldRoot) {
+      this.findingRoot = true;
+      if (this.intersectionObserver) {
+        this.intersectionObserver.unobserve(oldRoot);
+      }
+      this.intersectionObserver = new IntersectionObserver(this.intersectionCallback);
+      this.intersectionObserver.observe(newRoot);
+    }
+  }
+}
+</script>

--- a/src/cosmicds/vue_components/SpeechSynthesizer.vue
+++ b/src/cosmicds/vue_components/SpeechSynthesizer.vue
@@ -200,6 +200,12 @@ module.exports = {
       const voiceName = this.options?.voice;
       this.defaultVoice = this.defaultVoice || window.speechSynthesis.getVoices().find(voice => this.defaultVoicesURIs.includes(voice.voiceURI));
       const options = { ...this.options };
+      if (options.rate === 0) {
+        options.rate = 1;
+      }
+      if (options.pitch === 0) {
+        options.pitch = 1;
+      }
       const voice = window.speechSynthesis.getVoices().find(voice => voice.name == voiceName) || this.defaultVoice;
       if (voice) {
         options.voice = voice;

--- a/src/cosmicds/vue_components/SpeechSynthesizer.vue
+++ b/src/cosmicds/vue_components/SpeechSynthesizer.vue
@@ -17,21 +17,9 @@
 <script>
 module.exports = {
   props: {
-    autoread: {
-      type: Boolean,
-      default: true,
-    },
-    voice: {
-      type: String,
-      default: null,
-    },
-    pitch: {
-      type: Number,
-      default: 1,
-    },
-    rate: {
-      type: Number,
-      default: 1,
+    options: {
+      type: Object,
+      default: null
     },
     selectors: {
       type: Array,
@@ -42,7 +30,7 @@ module.exports = {
       default: true
     },
     root: {
-      type: [Object, Function],
+      type: [Object, Function, HTMLElement],
       default: null
     },
     elementFilter: {
@@ -209,16 +197,14 @@ module.exports = {
       }
     },
     getSpeechOptions() {
-      const voiceName = this.voice;
+      const voiceName = this.options?.voice;
       this.defaultVoice = this.defaultVoice || window.speechSynthesis.getVoices().find(voice => this.defaultVoicesURIs.includes(voice.voiceURI));
+      const options = { ...this.options };
       const voice = window.speechSynthesis.getVoices().find(voice => voice.name == voiceName) || this.defaultVoice;
-      const options = {
-        autoread: this.autoread,
-        pitch: this.pitch,
-        rate: this.rate,
-      };
       if (voice) {
         options.voice = voice;
+      } else {
+        delete options.voice;
       }
       return options;
     },


### PR DESCRIPTION
This PR does the initial setup of the speech synthesizer for the new Solara configuration. This works, and the settings are connected, but there are a couple of caveats:

* Right now this has a bit of a "prop drilling" issue, where we have to pass the speech settings to every guideline just so they can get forwarded through to the synthesizer component. While this works fine, it feels to me like there should be a cleaner solution.
* The fact that we're passing in the speech settings as a prop also means that changes to the speech settings can cause component re-renders. This is particularly noticeable for the intro slideshow, which doesn't have any Python-side state, and thus updating speech settings causes a re-render and you have to start over.

@patudom pointed out that students are unlikely to adjust these settings often, so this shouldn't be a huge deal. But while this kinda works as a first implementation, I'm going to keep thinking of what the best way to update this is. @nmearl let me know if you have any thoughts on what a clean approach to this might be.