### PR TITLE
Fix issues with speech autochange

### DIFF
--- a/src/cosmicds/components/speech_settings/SpeechSettings.vue
+++ b/src/cosmicds/components/speech_settings/SpeechSettings.vue
@@ -79,21 +79,13 @@
 
 <script>
 module.exports = {
-  props: {
-    initialState: {
-      type: Object,
-      default: null,
-    }
-  },
   created() {
     window.speechSynthesis.onvoiceschanged = (_event) => {
       this.updateVoiceList();
     };
     this.updateVoiceList();
 
-    this.autoread = this.initialState?.autoread ?? false;
-    this.pitch = this.initialState?.pitch ?? 1;
-    this.rate = this.initialState?.rate ?? 1;
+    this.updateAttributes(this.initialState);
   },
   data() {
     return {
@@ -120,7 +112,12 @@ module.exports = {
   methods: {
     updateVoiceList() {
       this.voices = window.speechSynthesis.getVoices().filter(voice => this.voiceURIs.includes(voice.voiceURI));
-    }
+    },
+    updateAttributes(state) {
+      this.autoread = state?.autoread ?? false;
+      this.pitch = state?.pitch ?? 1;
+      this.rate = state?.rate ?? 1;
+    },
   },
   watch: {
     autoread(read) {
@@ -134,6 +131,9 @@ module.exports = {
     },
     voice(newVoice) {
       this.voice_changed(newVoice.voiceURI);
+    },
+    initialState(state) {
+      this.updateAttributes(state);
     }
   }
 }

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -186,7 +186,7 @@ def BaseLayout(
                     speech.set(settings)
                 SpeechSettings(
                     initial_state=initial_settings,
-                    event_autoread_changed=lambda read: update_speech_property("read", read),
+                    event_autoread_changed=lambda read: update_speech_property("autoread", read),
                     event_pitch_changed=lambda pitch: update_speech_property("pitch", pitch),
                     event_rate_changed=lambda rate: update_speech_property("rate", rate),
                     event_voice_changed=lambda voice: update_speech_property("voice", voice),

--- a/src/cosmicds/vue_components/SpeechSynthesizer.vue
+++ b/src/cosmicds/vue_components/SpeechSynthesizer.vue
@@ -115,7 +115,7 @@ module.exports = {
   methods: {
 
     triggerAutospeak(forceSpeak=true) {
-      if (this.autospeak) {
+      if (this.getSpeechOptions().autoread) {
         this.$nextTick(() => this.speak(forceSpeak));
       }
     },
@@ -341,6 +341,9 @@ module.exports = {
     // didn't seem to be enough - the DOM changes hadn't finished propagating yet.
     // But this does the trick, and I don't notice it at all
     autospeakOnChange(_item) {
+      if (this.speaking) {
+        this.stopThisSpeaking();
+      }
       setTimeout(() => {{
         this.triggerAutospeak();
       }}, 100);


### PR DESCRIPTION
This PR should resolve https://github.com/cosmicds/hubbleds/issues/613. With these changes, the behavior for the slideshows should be as follows:

* If autoread is set, changing slides will cause the current speech to stop, and the next slide will automatically start to be read
* If autoread isn't set, changing slides will still cause the current speech to stop