### PR TITLE
Minor fix to Contrast Brightness Control

### DIFF
--- a/src/cosmicds/vue_components/ContrastBrightnessControl.vue
+++ b/src/cosmicds/vue_components/ContrastBrightnessControl.vue
@@ -119,9 +119,13 @@ module.exports = {
   methods: {
     resetContrast() {
       this.contrast = 0;
+      this.$emit('change-contrast', this.contrast2Per(0))
+      this.updateStyle();
     },
     resetBrightness() {
       this.brightness = 1;
+      this.$emit('change-brightness', this.brightness2Per(1))
+      this.updateStyle();
     },
     resetStyle() {
       console.log('resetting style from contrast_brightness_control');


### PR DESCRIPTION
The control needs to emit the new brightness/contrast values when it is reset. We need this if we want to track the brightness like we did in the voila version. 