### PR TITLE
Update global and local state without changing instance

### DIFF
--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -1,4 +1,3 @@
-from pydantic import BaseModel
 from solara_enterprise import auth
 import hashlib
 import os
@@ -225,14 +224,8 @@ class BaseAPI:
 
     @staticmethod
     def _update_state(state: Reactive[BaseState], data: dict):
-        for key, value in data.items():
-            field = getattr(state.fields, key, None)
-            if field is None:
-                continue
-            state_value = getattr(state.value, key)
-            if isinstance(state_value, BaseModel):
-                value = state_value.__class__(**value)
-            Ref(field).set(value)
+        new_state = state.value.__class__(**data)
+        state.value.__dict__.update(new_state.__dict__)
 
 
 BASE_API = BaseAPI()

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -5,7 +5,7 @@ import os
 from requests import Session
 from functools import cached_property
 
-from .state import GLOBAL_STATE, BaseLocalState, BaseState, GlobalState
+from .state import BaseLocalState, BaseState, GlobalState
 from solara import Reactive
 from solara.lab import Ref
 from cosmicds.logger import setup_logger


### PR DESCRIPTION
This PR is intended to fix #341. The motivation for this is @johnarban's first note on https://github.com/cosmicds/hubbleds/pull/629. The issue is that we're grabbing the initial glue application information with the original global state instance, but then when we reset the global state instance that has a new data collection, and we then have two different ones floating around.

The approach here is to update via a dictionary (which I imagine will always be the JSON content of a request response). We iterate through the dictionary items and, if the key corresponds to an attribute of the state, `Ref`-update the state accordingly. The update method is simple and assumes that the only special handling needed is for Pydantic models.

In the Hubble story we only need to call this once (when the state-loading task finishes) and probably only need reactivity for a subset of fields, but I didn't want this approach to make any assumptions about what we'll generally want.