### PR TITLE
Allow displaying scatter points on dotplot viewer

### DIFF
--- a/src/cosmicds/viewers/dotplot/scatter_layer_artist.py
+++ b/src/cosmicds/viewers/dotplot/scatter_layer_artist.py
@@ -7,9 +7,10 @@ from glue.core import BaseData
 from glue.core.exceptions import IncompatibleAttribute
 from glue.utils import ensure_numerical
 from glue.viewers.common.layer_artist import LayerArtist
-from glue.viewers.scatter.state import ScatterLayerState
 
 from plotly.graph_objs import Scatter
+
+from cosmicds.viewers.dotplot.scatter_layer_state import ScatterLayerState
 
 
 __all__ = ["DotplotScatterLayerArtist"]

--- a/src/cosmicds/viewers/dotplot/scatter_layer_artist.py
+++ b/src/cosmicds/viewers/dotplot/scatter_layer_artist.py
@@ -133,7 +133,7 @@ class DotplotScatterLayerArtist(LayerArtist):
             self.enable()
 
         scatter = self._get_scatter()
-        scatter.update(x=x, y=[1 for _ in x])
+        scatter.update(x=x, y=[self.state.height for _ in x])
 
     def _create_scatter(self):
         if isinstance(self.layer, BaseData):

--- a/src/cosmicds/viewers/dotplot/scatter_layer_artist.py
+++ b/src/cosmicds/viewers/dotplot/scatter_layer_artist.py
@@ -59,9 +59,8 @@ class DotplotScatterLayerArtist(LayerArtist):
         super().__init__(
             viewer_state,
             layer_state=layer_state,
-            layer=layer
+            layer=layer,
         )
-        print("Called superclass init")
 
         self.view = view
 

--- a/src/cosmicds/viewers/dotplot/scatter_layer_artist.py
+++ b/src/cosmicds/viewers/dotplot/scatter_layer_artist.py
@@ -1,0 +1,214 @@
+from itertools import chain
+from uuid import uuid4
+
+from glue_plotly.common import color_info
+from glue_plotly.common.scatter2d import scatter_mode, size_info
+from glue.core import BaseData
+from glue.core.exceptions import IncompatibleAttribute
+from glue.utils import ensure_numerical
+from glue.viewers.common.layer_artist import LayerArtist
+from glue.viewers.scatter.state import ScatterLayerState
+
+from plotly.graph_objs import Scatter
+
+
+__all__ = ["DotplotScatterLayerArtist"]
+
+
+CMAP_PROPERTIES = {"cmap_mode", "cmap_att", "cmap_vmin", "cmap_vmax", "cmap"}
+MARKER_PROPERTIES = {
+    "size_mode",
+    "size_att",
+    "size_vmin",
+    "size_vmax",
+    "size_scaling",
+    "size",
+    "fill",
+}
+DENSITY_PROPERTIES = {"dpi", "stretch", "density_contrast"}
+VISUAL_PROPERTIES = (
+    CMAP_PROPERTIES
+    | MARKER_PROPERTIES
+    | DENSITY_PROPERTIES
+    | {"color", "alpha", "zorder", "visible"}
+)
+
+LIMIT_PROPERTIES = {"x_min", "x_max"}
+DATA_PROPERTIES = {
+    "layer",
+    "x_att",
+    "cmap_mode",
+    "size_mode",
+    "density_map",
+    "vector_visible",
+    "vector_arrowhead",
+    "vector_mode",
+    "vector_origin",
+    "line_visible",
+    "markers_visible",
+    "vector_scaling",
+}
+
+
+class DotplotScatterLayerArtist(LayerArtist):
+
+    _layer_state_cls = ScatterLayerState
+
+    def __init__(self, view, viewer_state, layer_state=None, layer=None):
+
+        super().__init__(
+            viewer_state,
+            layer_state=layer_state,
+            layer=layer
+        )
+        print("Called superclass init")
+
+        self.view = view
+
+        # Somewhat annoyingly, the trace that we pass in to be added
+        # is NOT the same instance that ends up living in the figure.
+        # (see basedatatypes.py line 2251 in the Plotly package)
+        # So we abuse the metadata entry of the trace to tag it with
+        # a UUID so that we can extract it when needed.
+        # Note that setting the UID directly (either in the Scatter
+        # constructor or after) doesn't seem to work - it gets
+        # overridden by Plotly
+        self._scatter_id = uuid4().hex
+        scatter = self._create_scatter()
+        self.view.figure.add_trace(scatter)
+
+        # We want to initialize these to some dummy UUIDs so that
+        # _get_lines, _get_error_bars, _get_vectors, etc. don't pick up
+        # any other traces that tools have added to the viewer, which
+        # will happen if these IDs are None
+        self._lines_id = uuid4().hex
+        self._error_id = uuid4().hex
+        self._vector_id = uuid4().hex
+
+        self._viewer_state.add_global_callback(self._update_display)
+        self.state.add_global_callback(self._update_display)
+        self.state.add_callback("zorder", self._update_zorder)
+
+    def remove(self):
+        self.view._remove_traces([self._get_scatter()])
+        self.view._remove_traces(self._get_lines())
+        self.view._remove_traces(self._get_error_bars())
+        self.view._remove_traces(self._get_vectors())
+        return super().remove()
+
+    def _get_traces_with_id(self, id):
+        return self.view.figure.select_traces(dict(meta=id))
+
+    def _get_scatter(self):
+        # The scatter trace should always exist
+        # so if somehow it doesn't, then create it
+        try:
+            return next(self._get_traces_with_id(self._scatter_id))
+        except StopIteration:
+            scatter = self._create_scatter()
+            self.view.figure.add_trace(scatter)
+            return scatter
+
+    def _get_lines(self):
+        return self._get_traces_with_id(self._lines_id)
+
+    def _get_error_bars(self):
+        return self._get_traces_with_id(self._error_id)
+
+    def _get_vectors(self):
+        return self._get_traces_with_id(self._vector_id)
+
+    def traces(self):
+        return chain([self._get_scatter()], self._get_lines(), self._get_error_bars(), self._get_vectors())
+
+    def _update_data(self):
+
+        try:
+            x = ensure_numerical(self.layer[self._viewer_state.x_att].ravel())
+        except (IncompatibleAttribute, IndexError):
+            if self._viewer_state.x_att is not None:
+                self.disable_invalid_attributes(self._viewer_state.x_att)
+            return
+        else:
+            self.enable()
+
+        scatter = self._get_scatter()
+        scatter.update(x=x, y=[1 for _ in x])
+
+    def _create_scatter(self):
+        if isinstance(self.layer, BaseData):
+            name = self.layer.label
+        else:
+            name = f"{self.layer.label} ({self.layer.data.label})"
+
+        scatter_info = dict(mode=scatter_mode(self.state),
+                            name=name,
+                            hoverinfo='all',
+                            unselected=dict(marker=dict(opacity=self.state.alpha)),
+                            meta=self._scatter_id)
+        scatter = Scatter(**scatter_info)
+        return scatter
+
+    def _update_display(self, force=False, **kwargs):
+        changed = self.pop_changed_properties()
+
+        if 'layout_update' in kwargs:
+            self.view._clear_traces()
+            scatter = self._create_scatter()
+            self.view.figure.add_trace(scatter)
+            force = True
+
+        if force or len(changed & DATA_PROPERTIES) > 0:
+            self._update_data()
+            force = True
+
+        if force or len(changed & VISUAL_PROPERTIES) > 0:
+            self._update_visual_attributes(changed, force=force)
+
+    def _update_zorder(self, *args):
+        current_traces = self.view.figure.data
+        traces = [self.view.selection_layer]
+        for layer in self.view.layers:
+            traces += list(layer.traces())
+        self.view.figure.data = traces + [t for t in current_traces if t not in traces]
+
+    def _update_visual_attributes(self, changed, force=False):
+
+        if not self.enabled:
+            return
+
+        # Only run select_traces once
+        scatter = self._get_scatter()
+
+        if self.state.markers_visible:
+            if force or \
+                    any(prop in changed for prop in CMAP_PROPERTIES) or \
+                    any(prop in changed for prop in ["color", "fill"]):
+
+                color = color_info(self.state)
+                if self.state.fill:
+                    scatter.marker.update(color=color,
+                                          line=dict(width=0),
+                                          opacity=self.state.alpha)
+                else:
+                    scatter.marker.update(color='rgba(0, 0, 0, 0)',
+                                          opacity=self.state.alpha,
+                                          line=dict(width=1,
+                                                    color=color)
+                                          )
+
+            if force or any(prop in changed for prop in MARKER_PROPERTIES):
+                scatter.marker['size'] = size_info(self.state)
+
+        if force or "alpha" in changed:
+            marker = scatter.marker
+            opacity_dict = dict(opacity=self.state.alpha)
+            marker.update(**opacity_dict)
+            scatter.update(marker=marker,
+                           unselected=dict(marker=opacity_dict))
+
+        if force or "visible" in changed:
+            scatter.visible = self.state.visible
+
+    def update(self, **kwargs):
+        self._update_display(force=True, **kwargs)

--- a/src/cosmicds/viewers/dotplot/scatter_layer_state.py
+++ b/src/cosmicds/viewers/dotplot/scatter_layer_state.py
@@ -74,9 +74,6 @@ class ScatterLayerState(MatplotlibLayerState, StretchStateMixin):
         self.size_att_helper = ComponentIDComboHelper(self, 'size_att',
                                                       numeric=True, datetime=False, categorical=False)
 
-        self.add_callback('points_mode', self._update_density_map_mode)
-        self.add_callback('density_map', self._on_density_map_change, priority=10000)
-
         ScatterLayerState.cmap_mode.set_choices(self, ['Fixed', 'Linear'])
         ScatterLayerState.size_mode.set_choices(self, ['Fixed', 'Linear'])
 
@@ -91,8 +88,6 @@ class ScatterLayerState(MatplotlibLayerState, StretchStateMixin):
         self.setup_stretch_callback()
         self.stretch = 'log'
 
-        if self.viewer_state is not None:
-            self._update_points_mode()
 
         self.add_callback('layer', self._on_layer_change)
         if layer is not None:

--- a/src/cosmicds/viewers/dotplot/scatter_layer_state.py
+++ b/src/cosmicds/viewers/dotplot/scatter_layer_state.py
@@ -21,6 +21,10 @@ class ScatterLayerState(MatplotlibLayerState, StretchStateMixin):
     A state class that includes all the attributes for layers in a scatter plot.
     """
 
+    # Height
+
+    height = DDCProperty(1, docstring="The y-value at which to display scatter points")
+
     # Color
 
     cmap_mode = DDSCProperty(docstring="Whether to use color to encode an attribute")

--- a/src/cosmicds/viewers/dotplot/scatter_layer_state.py
+++ b/src/cosmicds/viewers/dotplot/scatter_layer_state.py
@@ -1,0 +1,157 @@
+import numpy as np
+
+from glue.core import BaseData, Subset
+
+from glue.config import colormaps
+from glue.viewers.matplotlib.state import (MatplotlibLayerState,
+                                           DeferredDrawCallbackProperty as DDCProperty,
+                                           DeferredDrawSelectionCallbackProperty as DDSCProperty)
+from glue.core.state_objects import StateAttributeLimitsHelper
+from echo import keep_in_sync, delay_callback
+from glue.core.data_combo_helper import ComponentIDComboHelper, ComboHelper
+from glue.core.exceptions import IncompatibleAttribute
+from glue.viewers.common.stretch_state_mixin import StretchStateMixin
+
+
+__all__ = ['ScatterLayerState']
+
+
+class ScatterLayerState(MatplotlibLayerState, StretchStateMixin):
+    """
+    A state class that includes all the attributes for layers in a scatter plot.
+    """
+
+    # Color
+
+    cmap_mode = DDSCProperty(docstring="Whether to use color to encode an attribute")
+    cmap_att = DDSCProperty(docstring="The attribute to use for the color")
+    cmap_vmin = DDCProperty(docstring="The lower level for the colormap")
+    cmap_vmax = DDCProperty(docstring="The upper level for the colormap")
+    cmap = DDCProperty(docstring="The colormap to use (when in colormap mode)")
+
+    # Markers
+
+    markers_visible = DDCProperty(True, docstring="Whether to show markers")
+    size = DDCProperty(docstring="The size of the markers")
+    size_mode = DDSCProperty(docstring="Whether to use size to encode an attribute")
+    size_att = DDSCProperty(docstring="The attribute to use for the size")
+    size_vmin = DDCProperty(docstring="The lower level for the size mapping")
+    size_vmax = DDCProperty(docstring="The upper level for the size mapping")
+    size_scaling = DDCProperty(1, docstring="Relative scaling of the size")
+    fill = DDCProperty(True, docstring="Whether to fill the markers")
+
+    # Density map
+
+    density_map = DDCProperty(False, docstring="Whether to show the points as a density map")
+    density_contrast = DDCProperty(1, docstring="The dynamic range of the density map")
+
+    # Note that we keep the dpi in the viewer state since we want it to always
+    # be in sync between layers.
+
+    # Line
+
+    line_visible = DDCProperty(False, docstring="Whether to show a line connecting all positions")
+    linewidth = DDCProperty(1, docstring="The line width")
+    linestyle = DDSCProperty(docstring="The line style")
+
+    def __init__(self, viewer_state=None, layer=None, **kwargs):
+
+        super(ScatterLayerState, self).__init__(viewer_state=viewer_state, layer=layer)
+
+        self.limits_cache = {}
+
+        self.cmap_lim_helper = StateAttributeLimitsHelper(self, attribute='cmap_att',
+                                                          lower='cmap_vmin', upper='cmap_vmax',
+                                                          limits_cache=self.limits_cache)
+
+        self.size_lim_helper = StateAttributeLimitsHelper(self, attribute='size_att',
+                                                          lower='size_vmin', upper='size_vmax',
+                                                          limits_cache=self.limits_cache)
+
+        self.cmap_att_helper = ComponentIDComboHelper(self, 'cmap_att',
+                                                      numeric=True, datetime=False, categorical=False)
+
+        self.size_att_helper = ComponentIDComboHelper(self, 'size_att',
+                                                      numeric=True, datetime=False, categorical=False)
+
+        self.add_callback('points_mode', self._update_density_map_mode)
+        self.add_callback('density_map', self._on_density_map_change, priority=10000)
+
+        ScatterLayerState.cmap_mode.set_choices(self, ['Fixed', 'Linear'])
+        ScatterLayerState.size_mode.set_choices(self, ['Fixed', 'Linear'])
+
+        linestyle_display = {'solid': '–––––––',
+                             'dashed': '– – – – –',
+                             'dotted': '· · · · · · · ·',
+                             'dashdot': '– · – · – ·'}
+
+        ScatterLayerState.linestyle.set_choices(self, ['solid', 'dashed', 'dotted', 'dashdot'])
+        ScatterLayerState.linestyle.set_display_func(self, linestyle_display.get)
+
+        self.setup_stretch_callback()
+        self.stretch = 'log'
+
+        if self.viewer_state is not None:
+            self._update_points_mode()
+
+        self.add_callback('layer', self._on_layer_change)
+        if layer is not None:
+            self._on_layer_change()
+
+        self.cmap = colormaps.members[0][1]
+        self.add_callback('cmap_att', self._check_for_preferred_cmap)
+
+        self.size = self.layer.style.markersize
+
+        self._sync_size = keep_in_sync(self, 'size', self.layer.style, 'markersize')
+
+        self.update_from_dict(kwargs)
+
+    def _check_for_preferred_cmap(self, *args):
+        if isinstance(self.layer, BaseData):
+            layer = self.layer
+        else:
+            layer = self.layer.data
+        actual_component = layer.get_component(self.cmap_att)
+        if getattr(actual_component, 'preferred_cmap', False):
+            self.cmap = actual_component.preferred_cmap
+
+    def _on_layer_change(self, layer=None):
+
+        with delay_callback(self, 'cmap_vmin', 'cmap_vmax', 'size_vmin', 'size_vmax'):
+
+            if self.layer is None:
+                self.cmap_att_helper.set_multiple_data([])
+                self.size_att_helper.set_multiple_data([])
+            else:
+                self.cmap_att_helper.set_multiple_data([self.layer])
+                self.size_att_helper.set_multiple_data([self.layer])
+
+    def flip_cmap(self):
+        """
+        Flip the cmap_vmin/cmap_vmax limits.
+        """
+        self.cmap_lim_helper.flip_limits()
+
+    def flip_size(self):
+        """
+        Flip the size_vmin/size_vmax limits.
+        """
+        self.size_lim_helper.flip_limits()
+
+    @property
+    def cmap_name(self):
+        return colormaps.name_from_cmap(self.cmap)
+
+    @classmethod
+    def __setgluestate__(cls, rec, context):
+        # Patch for glue files produced with glue v0.11
+        if 'style' in rec['values']:
+            style = context.object(rec['values'].pop('style'))
+            if style == 'Scatter':
+                rec['values']['markers_visible'] = True
+                rec['values']['line_visible'] = False
+            elif style == 'Line':
+                rec['values']['markers_visible'] = False
+                rec['values']['line_visible'] = True
+        return super(ScatterLayerState, cls).__setgluestate__(rec, context)

--- a/src/cosmicds/viewers/dotplot/viewer.py
+++ b/src/cosmicds/viewers/dotplot/viewer.py
@@ -39,6 +39,6 @@ class PlotlyDotPlotView(PlotlyHistogramView):
 
     # For now, subsets have the same layer type as their parent
     def get_subset_layer_artist(self, layer=None, layer_state=None):
-        if layer is not None and layer.parent.uuid in self._scatter_layers:
+        if layer is not None and layer.data.uuid in self._scatter_layers:
             return DotplotScatterLayerArtist(self, self.state, layer_state=layer_state, layer=layer)
         return super().get_subset_layer_artist(layer, layer_state)

--- a/src/cosmicds/viewers/dotplot/viewer.py
+++ b/src/cosmicds/viewers/dotplot/viewer.py
@@ -1,7 +1,11 @@
+from glue.core import Data
 from glue_plotly.viewers.histogram import PlotlyHistogramView
 from glue_plotly.viewers.histogram.dotplot_layer_artist import PlotlyDotplotLayerArtist
 
 from cosmicds.viewers.dotplot.state import DotPlotViewerState
+from cosmicds.viewers.dotplot.scatter_layer_artist import DotplotScatterLayerArtist 
+
+from typing import Literal
 
 __all__ = ["PlotlyDotPlotView"]
 
@@ -13,3 +17,28 @@ class PlotlyDotPlotView(PlotlyHistogramView):
     _state_cls = DotPlotViewerState
     _data_artist_cls = PlotlyDotplotLayerArtist
     _subset_artist_cls = PlotlyDotplotLayerArtist
+
+    _scatter_layers = set()
+
+    def add_data(self, data: Data, layer_type: Literal["dotplot"] | Literal["scatter"] = "dotplot"):
+         
+        if layer_type == "scatter":
+            self._scatter_layers.add(data.uuid)
+
+        super().add_data(data)
+
+    # def add_subset(self, data: Data, layer_type: Literal["dotplot"] | Literal["scatter"] = "dotplot"):
+    #     if layer_type == "scatter":
+    #         self._scatter_layers.add(data.uuid)
+    #     super().add_subset(data)
+
+    def get_data_layer_artist(self, layer=None, layer_state=None):
+        if layer is not None and layer.uuid in self._scatter_layers:
+            return DotplotScatterLayerArtist
+        return super().get_data_layer_artist(layer, layer_state)
+
+    # For now, subsets have the same layer type as their parent
+    def get_subset_layer_artist(self, layer=None, layer_state=None):
+        if layer is not None and layer.parent.uuid in self._scatter_layers:
+            return DotplotScatterLayerArtist
+        return super().get_subset_layer_artist(layer, layer_state)

--- a/src/cosmicds/viewers/dotplot/viewer.py
+++ b/src/cosmicds/viewers/dotplot/viewer.py
@@ -34,11 +34,11 @@ class PlotlyDotPlotView(PlotlyHistogramView):
 
     def get_data_layer_artist(self, layer=None, layer_state=None):
         if layer is not None and layer.uuid in self._scatter_layers:
-            return DotplotScatterLayerArtist
+            return DotplotScatterLayerArtist(self, self.state, layer_state=layer_state, layer=layer)
         return super().get_data_layer_artist(layer, layer_state)
 
     # For now, subsets have the same layer type as their parent
     def get_subset_layer_artist(self, layer=None, layer_state=None):
         if layer is not None and layer.parent.uuid in self._scatter_layers:
-            return DotplotScatterLayerArtist
+            return DotplotScatterLayerArtist(self, self.state, layer_state=layer_state, layer=layer)
         return super().get_subset_layer_artist(layer, layer_state)

--- a/src/cosmicds/viewers/viewer.py
+++ b/src/cosmicds/viewers/viewer.py
@@ -44,15 +44,15 @@ def cds_viewer(viewer_class, name, viewer_tools=[], label=None, state_cls=None):
         def ignore(self, condition):
             self.ignore_conditions.append(condition)
 
-        def add_data(self, data):
+        def add_data(self, data, **kwargs):
             if any(condition(data) for condition in self.ignore_conditions):
                 return False
-            return super().add_data(data)
+            return super().add_data(data, **kwargs)
 
-        def add_subset(self, subset):
+        def add_subset(self, subset, **kwargs):
             if any(condition(subset) for condition in self.ignore_conditions):
                 return False
-            return super().add_subset(subset)
+            return super().add_subset(subset, **kwargs)
 
         # The argument here can be either a Data or Subset object
         def layer_artist_for_data(self, data):


### PR DESCRIPTION
This PR provides a solution to https://github.com/cosmicds/hubbleds/issues/639. The approach that I took here is to create a "scatter" layer that can live on a dotplot viewer. The x-positions of the layer are set via the viewer state's `x_att`, and the y-positions are set via a property in the layer's state (default is 1). I also updated the viewer to allow specifying that a layer will be a scatter layer when adding data (I borrowed the approach here from the vispy volume viewer, which is another viewer that can support multiple data layer types). The advantage of doing things this way is that it should be a reusable solution if we want this functionality again.