### PR TITLE
Create Google Analytics support component

### DIFF
--- a/src/cosmicds/components/__init__.py
+++ b/src/cosmicds/components/__init__.py
@@ -8,3 +8,4 @@ from .statistics_selector import StatisticsSelector
 from .percentage_selector import PercentageSelector
 from .refresh_button import RefreshButton
 from .info_dialog.info_dialog import InfoDialog
+from .google_analytics_support.google_analytics_support import GoogleAnalyticsSupport

--- a/src/cosmicds/components/google_analytics_support/GoogleAnalyticsSupport.vue
+++ b/src/cosmicds/components/google_analytics_support/GoogleAnalyticsSupport.vue
@@ -1,17 +1,27 @@
 <script>
 export default {
   mounted() {
-    const fetchScript = document.createElement("script");
-    fetchScript.async = true;
-    fetchScript.src = `https://www.googletagmanager.com/gtag/js?id=${this.tag}`;
-    document.head.appendChild(fetchScript);
-
-    const activateScript = document.createElement("script");
-    activateScript.text = `window.dataLayer = window.dataLayer || [];
-                           function gtag(){dataLayer.push(arguments);}
-                           gtag('js', new Date());
-                           gtag('config', "${this.tag}");`
-    document.head.appendChild(activateScript);
+    const gaScript = document.createElement("script");
+    gaScript.text = `
+      // Logic derived from https://stackoverflow.com/a/61839170
+      const local = (function (hostname=window.location.hostname) {
+        return (
+          (['localhost', '127.0.0.1', '', '::1'].includes(hostname))
+          || (hostname.startsWith('192.168.'))
+          || (hostname.startsWith('10.'))
+        );
+      })();
+      if (!local) {
+        const script = document.createElement("script");
+        script.async = true;
+        script.src = "https://www.googletagmanager.com/gtag/js?id=${this.tag}";
+        document.head.appendChild(script);
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', "${this.tag}");
+      }`
+    document.head.appendChild(gaScript);
   },
 
   props: {

--- a/src/cosmicds/components/google_analytics_support/GoogleAnalyticsSupport.vue
+++ b/src/cosmicds/components/google_analytics_support/GoogleAnalyticsSupport.vue
@@ -1,10 +1,17 @@
 <script>
 export default {
   mounted() {
-    const gaScript = document.createElement('script');
-    gaScript.async = true;
-    gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${this.tag}`;
-    document.head.appendChild(gaScript);
+    const fetchScript = document.createElement("script");
+    fetchScript.async = true;
+    fetchScript.src = `https://www.googletagmanager.com/gtag/js?id=${this.tag}`;
+    document.head.appendChild(fetchScript);
+
+    const activateScript = document.createElement("script");
+    activateScript.text = `window.dataLayer = window.dataLayer || [];
+                           function gtag(){dataLayer.push(arguments);}
+                           gtag('js', new Date());
+                           gtag('config', ${this.tag});`
+    document.head.appendChild(activateScript);
   },
 
   props: {

--- a/src/cosmicds/components/google_analytics_support/GoogleAnalyticsSupport.vue
+++ b/src/cosmicds/components/google_analytics_support/GoogleAnalyticsSupport.vue
@@ -10,7 +10,7 @@ export default {
     activateScript.text = `window.dataLayer = window.dataLayer || [];
                            function gtag(){dataLayer.push(arguments);}
                            gtag('js', new Date());
-                           gtag('config', ${this.tag});`
+                           gtag('config', "${this.tag}");`
     document.head.appendChild(activateScript);
   },
 

--- a/src/cosmicds/components/google_analytics_support/GoogleAnalyticsSupport.vue
+++ b/src/cosmicds/components/google_analytics_support/GoogleAnalyticsSupport.vue
@@ -1,0 +1,17 @@
+<script>
+export default {
+  mounted() {
+    const gaScript = document.createElement('script');
+    gaScript.async = true;
+    gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${this.tag}`;
+    document.head.appendChild(gaScript);
+  },
+
+  props: {
+    tag: {
+      type: String,
+      required: true,
+    }
+  }
+}
+</script>

--- a/src/cosmicds/components/google_analytics_support/google_analytics_support.py
+++ b/src/cosmicds/components/google_analytics_support/google_analytics_support.py
@@ -1,0 +1,6 @@
+import solara
+
+
+@solara.component_vue("GoogleAnalyticsSupport.vue")
+def GoogleAnalyticsSupport(tag):
+    pass

--- a/src/cosmicds/components/google_analytics_support/google_analytics_support.py
+++ b/src/cosmicds/components/google_analytics_support/google_analytics_support.py
@@ -2,5 +2,5 @@ import solara
 
 
 @solara.component_vue("GoogleAnalyticsSupport.vue")
-def GoogleAnalyticsSupport(tag):
+def GoogleAnalyticsSupport(tag: str):
     pass


### PR DESCRIPTION
This PR adds a Google Analytics support component, similar to what we've done for MathJax and Plotly. This component takes in the tracking tag to be used so that we can use different tags for different stories if necessary.