### PR TITLE
Use `expected_size` field to set class size in app

### DIFF
--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -54,9 +54,9 @@ class BaseAPI:
     def update_class_size(self, state: Reactive[GlobalState]):
         class_id = state.value.classroom.class_info["id"]
         size_json = self.request_session.get(
-            f"{self.API_URL}/classes/size/{class_id}"
+            f"{self.API_URL}/classes/expected-size/{class_id}"
         ).json()
-        Ref(state.fields.classroom.size).set(size_json["size"])
+        Ref(state.fields.classroom.size).set(size_json["expected_size"])
 
     def load_user_info(self, story_name: str, state: Reactive[GlobalState]):
         student_json = self.request_session.get(

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -70,7 +70,7 @@ class BaseAPI:
 
         Ref(state.fields.student.id).set(sid)
         Ref(state.fields.classroom.class_info).set(class_json["class"])
-        # Ref(state.fields.classroom.size).set(class_json["expected_size"])
+        Ref(state.fields.classroom.size).set(class_json["class"]["expected_size"])
 
         logger.info("Loaded user info for user `%s`.", state.value.student.id)
 

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -70,7 +70,7 @@ class BaseAPI:
 
         Ref(state.fields.student.id).set(sid)
         Ref(state.fields.classroom.class_info).set(class_json["class"])
-        Ref(state.fields.classroom.size).set(class_json["size"])
+        # Ref(state.fields.classroom.size).set(class_json["expected_size"])
 
         logger.info("Loaded user info for user `%s`.", state.value.student.id)
 


### PR DESCRIPTION
This PR updates the app to use the teacher-set "expected size" for the class, rather than the number of students currently in the class.