### PR TITLE
Fix doubled logging messages

### DIFF
--- a/src/cosmicds/logger.py
+++ b/src/cosmicds/logger.py
@@ -3,7 +3,7 @@ import logging
 
 class CustomFormatter(logging.Formatter):
     # Define the custom format for log messages
-    FORMAT = "[%(asctime)s][%(levelname)8s][%(name)8s]:%(message)s"
+    FORMAT = "[%(asctime)s][%(levelname)8s][%(name)8s][%(filename)s:%(lineno)s]:%(message)s"
 
     def __init__(self):
         super().__init__(self.FORMAT, datefmt="%Y-%m-%d %H:%M:%S")

--- a/src/cosmicds/logger.py
+++ b/src/cosmicds/logger.py
@@ -25,4 +25,5 @@ def setup_logger(name, level=logging.DEBUG):
     if not logger.hasHandlers():
         logger.addHandler(ch)
 
+    logger.propagate = False
     return logger

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -215,7 +215,7 @@ class BaseAPI:
         BaseAPI._update_state(global_state, global_state_json)
 
         local_state_json = story_json.get("story", {})
-        logger.info(local_state_json)
+        logger.debug(local_state_json)
         BaseAPI._update_state(local_state, local_state_json)
 
         logger.info("Updated local state from database.")


### PR DESCRIPTION
This PR prevents duplicate logging messages present when I run the app locally. It also adds the line # for easier references. Perhaps this isn't an issue for anyone else
