### PR TITLE
Make components more generic

### DIFF
--- a/src/cosmicds/components/viewer_layout.py
+++ b/src/cosmicds/components/viewer_layout.py
@@ -1,4 +1,5 @@
 from cosmicds.utils import make_figure_autoresize, DEFAULT_VIEWER_HEIGHT
+from glue_plotly.viewers.common import PlotlyBaseView
 import solara
 import reacton.ipyvuetify as rv
 
@@ -24,7 +25,8 @@ def ToolBar(viewer):
 
 @solara.component
 def ViewerLayout(viewer, viewer_height=DEFAULT_VIEWER_HEIGHT):
-    make_figure_autoresize(viewer.figure_widget, viewer_height)
+    if isinstance(viewer, PlotlyBaseView):
+        make_figure_autoresize(viewer.figure_widget, viewer_height)
     # viewer.figure_widget.layout.height = 600
     layout = solara.Column(
         children=[

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 from warnings import filterwarnings
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from typing import Optional
 
 import solara
@@ -146,13 +146,16 @@ def BaseLayout(
                             outlined=True,
                             dense=True,
                         )
-                        rv.TextField(
-                            value=f"{version('hubbleds')}",
-                            label="HubbleDS Version",
-                            readonly=True,
-                            outlined=True,
-                            dense=True,
-                        )
+                        try:
+                            rv.TextField(
+                                value=f"{version('hubbleds')}",
+                                label="HubbleDS Version",
+                                readonly=True,
+                                outlined=True,
+                                dense=True,
+                            )
+                        except PackageNotFoundError:
+                            pass
                         rv.TextField(
                             value=f"{GLOBAL_STATE.value.student.id}",
                             label="Student ID",


### PR DESCRIPTION
While working on setting up the Solara app/layout for the TEMPO story, I came across a couple of Hubble-specific things in our base components:

* The base layout expects `hubbleds` to be installed, as it shows the Hubble version in the debugging info. I think this is useful while we're still working on it, but I've wrapped the component in a try-catch so that it can still run if `hubbleds` isn't present in the environment
* The `ViewerLayout` component sets up some auto-resizing functionality for the Plotly viewers, but this means that it doesn't work to wrap a non-Plotly viewer. This PR fixes that.