### PR TITLE
Override glue settings

### DIFF
--- a/src/cosmicds/__init__.py
+++ b/src/cosmicds/__init__.py
@@ -20,6 +20,8 @@ from pathlib import Path
 import ipyvue
 import re
 
+from glue.config import settings
+
 # Register any custom Vue components
 comp_dir = Path(__file__).parent / "vue_components"
 
@@ -32,3 +34,8 @@ def load_custom_vue_components():
                 name=comp_name,
                 file_name=comp_path,
             )
+
+
+# Override glue settings
+settings.BACKGROUND_COLOR = "white"
+settings.FOREGROUND_COLOR = "black"


### PR DESCRIPTION
This PR overrides the user's existing glue settings (if they have any) to use white background/black foreground. This won't overwrite their saved settings - it's purely something that happens at runtime for us. This resolves https://github.com/cosmicds/hubbleds/issues/703.