### PR TITLE
Have layer toggle listen to external visibility changes

### DIFF
--- a/src/cosmicds/components/layer_toggle.py
+++ b/src/cosmicds/components/layer_toggle.py
@@ -7,6 +7,7 @@ from traitlets import List, observe
 import solara
 import os
 
+
 class _LayerToggle(VuetifyTemplate):
     # absolute path for __file__ /.. / .. / "vue_components" / "layer_toggle.vue"
     template_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "layer_toggle.vue"))
@@ -50,7 +51,8 @@ class _LayerToggle(VuetifyTemplate):
         except ValueError:
             return len(layers) + 1
 
-    def _update_layer_visibility(self, layer):
+    def _update_layer_visibility(self, msg: LayerArtistVisibilityMessage):
+        layer = msg.layer_artist
         layers = self.viewer.layers
         index = self._layer_index(layers, layer)
         if index < len(layers):

--- a/src/cosmicds/components/layer_toggle.py
+++ b/src/cosmicds/components/layer_toggle.py
@@ -1,4 +1,4 @@
-from echo import delay_callback, ignore_callback
+from echo import delay_callback
 from echo.callback_container import CallbackContainer
 from glue.core.message import LayerArtistVisibilityMessage
 from glue.viewers.common.layer_artist import LayerArtist
@@ -27,7 +27,6 @@ class _LayerToggle(VuetifyTemplate):
         self.viewer.session.hub.subscribe(self.viewer.session.data_collection,
                                           LayerArtistVisibilityMessage,
                                           handler=self._update_layer_visibility)
-
 
     def _ignore_layer(self, layer):
         for cb in self._ignore_conditions:


### PR DESCRIPTION
Currently the layer toggle component is written to expect itself to be the only source of changes to layer visibility, but there are times when we manipulate the visibility of certain layers in the backend. This PR adds a message listener that allows the state of the toggler to update to reflect these changes.

To test this, one can go to stage 6 of the Hubble data story. Between markers `pro_dat4` and `pro_dat5`, we manually adjust the visibilities of the Hubble 1929 and HST key layers. With these changes, the layer toggle component should update to match.