### PR TITLE
Add viewer subtitle and use it with statistics/percentage selectors

### DIFF
--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -193,8 +193,7 @@ def PercentageSelector(viewers: List[Viewer],
             else:
                 unit_str = ""
             label_text = f"{option}% range: {bottom_str} \u2013 {top_str}{unit_str}"
-            subtitle = viewer.state.subtitle
-            if subtitle:
+            if viewer.state.subtitle:
                 label_text = (" " * 10) + label_text
             labels.append(label_text)
             viewer.state.subtitle += label_text

--- a/src/cosmicds/components/percentage_selector.py
+++ b/src/cosmicds/components/percentage_selector.py
@@ -20,6 +20,7 @@ def PercentageSelector(viewers: List[Viewer],
                        **kwargs):
     
     selected = solara.use_reactive(None)
+    viewer_labels, set_viewer_labels = solara.use_state([])
     radio_color = "#1e90ff"
     options = [50, 68, 95]
     last_updated = selected.value 
@@ -102,6 +103,13 @@ def PercentageSelector(viewers: List[Viewer],
             rounded_bound += res 
         return rounded_bound
 
+    def _clear_viewer_label(index):
+        viewer = viewers[index]
+        try:
+            viewer.state.subtitle = viewer.state.subtitle.replace(viewer_labels[index], "")
+        except IndexError:
+            pass
+
     def _update():
         nonlocal last_updated
 
@@ -112,18 +120,19 @@ def PercentageSelector(viewers: List[Viewer],
         if option is None:
             states = []
             for (index, viewer) in enumerate(viewers):
-                viewer.figure.layout.annotations = []
+                _clear_viewer_label(index)
                 if layers[index] is not None:
                     layers[index].state.color = original_colors[index]
-                    # viewer_layouts[index].set_subtitle(None)
                 state = array([False for _ in range(glue_data[index].size)])
                 states.append(state)
             _update_subsets(states)
+            set_viewer_labels([])
             return option
 
         states = []
+        labels = []
         for index, (viewer, viewer_bins) in enumerate(zip(viewers, bins)):
-            viewer.figure.layout.annotations = []
+            _clear_viewer_label(index)
             component_id = viewer.state.x_att
             data = glue_data[index][component_id]
             layer = layers[index]
@@ -184,11 +193,14 @@ def PercentageSelector(viewers: List[Viewer],
             else:
                 unit_str = ""
             label_text = f"{option}% range: {bottom_str} \u2013 {top_str}{unit_str}"
-            viewer.figure.add_annotation(text=label_text, xref="paper", yref="paper",
-                                         x=0.5, y=1.2, showarrow=False)
-            
+            subtitle = viewer.state.subtitle
+            if subtitle:
+                label_text = (" " * 10) + label_text
+            labels.append(label_text)
+            viewer.state.subtitle += label_text
 
         _update_subsets(states)
+        set_viewer_labels(labels)
 
         return option
 

--- a/src/cosmicds/viewers/state.py
+++ b/src/cosmicds/viewers/state.py
@@ -22,6 +22,8 @@ def cds_viewer_state(state_class):
         viewer_height = CallbackProperty(DEFAULT_VIEWER_HEIGHT)
         viewer_width = CallbackProperty(400)
 
+        subtitle = CallbackProperty("")
+
         @staticmethod
         def tick_spacing(naive_spacing):
             mantissa, exp = frexp10(naive_spacing)

--- a/src/cosmicds/viewers/viewer.py
+++ b/src/cosmicds/viewers/viewer.py
@@ -1,5 +1,8 @@
+from uuid import uuid4
+
 from echo import add_callback
 from glue.config import viewer_tool
+from glue_plotly.viewers import PlotlyBaseView
 
 from cosmicds.widgets.toolbar import Toolbar
 
@@ -25,6 +28,21 @@ def cds_viewer(viewer_class, name, viewer_tools=[], label=None, state_cls=None):
             self.ignore_conditions = []
             add_callback(self.state, "xtick_values", self._update_xtick_values)
             add_callback(self.state, "ytick_values", self._update_ytick_values)
+
+            if issubclass(viewer_class, PlotlyBaseView):
+                add_callback(self.state, "subtitle", self._update_plotly_subtitle)
+                self._create_plotly_subtitle(self.state.subtitle)
+
+        def _create_plotly_subtitle(self, text=None):
+            self.figure.add_annotation(text=text,
+                                       xref="paper", yref="paper",
+                                       x=0.5, y=1.2,
+                                       showarrow=False)
+
+        def _update_plotly_subtitle(self, text=None):
+            subtitle = next(self.figure.select_annotations(), None)
+            if subtitle is not None:
+                subtitle.update(text=text)
 
         def initialize_toolbar(self):
 


### PR DESCRIPTION
This PR resolves https://github.com/cosmicds/hubbleds/issues/734. The approach taken here is to add a subtitle to our CDS viewer wrapper classes, at least when the base viewer class is a Plotly viewer, and use that in the percentage and statistics selectors. The subtitle is defined on the viewer state and updating of the annotation is handled by the viewer, meaning the selector components only need to update the subtitle string appropriately.

Currently I have it set up so that the statistics text (if any) is first in the subtitle text ordering (see the screenshot from my testing below). We can think of a more robust system for this sort of thing in the future if we have more components that manipulate the subtitle.

![subtitle](https://github.com/user-attachments/assets/cca8c664-1166-459d-ad6c-12cb6457578c)
