### PR TITLE
Use "default" states when not loading from database

### DIFF
--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -4,7 +4,7 @@ import os
 from requests import Session
 from functools import cached_property
 
-from .state import BaseLocalState, BaseState, GlobalState
+from .state import GLOBAL_STATE, BaseLocalState, BaseState, GlobalState, Student
 from solara import Reactive
 from solara.lab import Ref
 from cosmicds.logger import setup_logger
@@ -212,8 +212,8 @@ class BaseAPI:
         else:
             logger.info("Skipping retrieval of Global and Local states.")
             story_json = {
-                "app": GlobalState().model_dump(),
-                "story": local_state.value.as_dict(),
+                "app": GlobalState(student=GLOBAL_STATE.value.student).model_dump(),
+                "story": type(local_state.value)(title=local_state.value.title, story_id=local_state.value.story_id).as_dict(),
             }
 
         global_state_json = story_json.get("app", {})


### PR DESCRIPTION
This is an attempt to fix https://github.com/cosmicds/hubbleds/issues/741. This updates the remote handler to explicitly set the current state to an empty "default" state when we aren't reading from the database.

@patudom @johnarban if you guys could try this out and tell me whether it works for you as well, that would be great