### PR TITLE
Explicitly check whether local state is `None`

### DIFF
--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -207,7 +207,7 @@ def BaseLayout(
             )
 
             with rv.Chip(class_="ma-2 piggy-chip"):                    
-                if local_state:
+                if local_state is not None:
                     # check that this doesn't make solara render the whole app. if it does, move the chip into its own component.
                     solara.Text(f"{local_state.value.piggybank_total} Points")
 


### PR DESCRIPTION
With the newest solara update, we can't just use a reactive as a boolean (unless we set a particular settings flag). This PR updates a problematic check in the base layout to explicitly check whether the local state reactive is `None`.