### PR TITLE
Emit update event only if valid response

### DIFF
--- a/src/cosmicds/vue_components/FreeResponse.vue
+++ b/src/cosmicds/vue_components/FreeResponse.vue
@@ -138,7 +138,7 @@ module.exports = {
     },
 
     onBlur(_event) {
-      if (this.tag !== undefined) {
+      if (this.tag !== undefined && this.isValid(this.response)==true) {
         this.dispatchUpdateEvent();
       }
     },


### PR DESCRIPTION
Ensure the update event dispatch occurs only when the response is valid.

Not critical, but goes along with https://github.com/cosmicds/hubbleds/pull/774