### PR TITLE
Pin solara to working version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,8 +57,9 @@ install_requires =
     ipyvuetify
     numpy<2.0.0
     reacton
-    solara-ui @ git+https://github.com/nmearl/solara.git
-    solara-enterprise
+    solara==1.42.0
+    solara-enterprise==1.42.0
+    solara-ui @ git+https://github.com/nmearl/solara.git@v1.42
     traitlets
 
 [options.packages.find]


### PR DESCRIPTION
This PR pins the **main** app's solara version to the last working version of solara that avoided the solara-enterprise auth0 issues.