### PR TITLE
Add viewer state option for controlling how to reset limits

### DIFF
--- a/src/cosmicds/viewers/state.py
+++ b/src/cosmicds/viewers/state.py
@@ -24,6 +24,8 @@ def cds_viewer_state(state_class):
 
         subtitle = CallbackProperty("")
 
+        reset_limits_from_visible = CallbackProperty(True)
+
         @staticmethod
         def tick_spacing(naive_spacing):
             mantissa, exp = frexp10(naive_spacing)
@@ -153,7 +155,9 @@ class CDSScatterViewerState(ScatterViewerState):
         max_value = max((b[1] for b in bounds), default=1)
         return min_value, max_value
     
-    def reset_limits(self, visible_only=True):
+    def reset_limits(self, visible_only=None):
+        if visible_only is None:
+            visible_only = getattr(self, "reset_limits_from_visible", True)
         if not visible_only:
             super().reset_limits()
             return
@@ -202,7 +206,9 @@ class CDSHistogramViewerState(PlotlyHistogramViewerState):
             self.x_min = min_value
             self.x_max = max_value - spacing(max_value)
     
-    def reset_limits(self, visible_only=True):
+    def reset_limits(self, visible_only=None):
+        if visible_only is None:
+            visible_only = getattr(self, "reset_limits_from_visible", True)
         if not visible_only:
             super().reset_limits()
             return


### PR DESCRIPTION
Currently our CosmicDS viewer state wrapper adds a `visible_only` flag to the `reset_limits` method that allows specifying whether or not to use only visible layers for the limit reset calculation. This has worked great for us, but one problem spot is with the home tool, which doesn't allow us a convenient way to specify this flag. Rather than create a separate version of this tool, this PR adds a `reset_limits_from_visible` member in the viewer state that serves as that viewer's "default" value for `visible_only`. This allows us to change things on a viewer-by-viewer basis, and even on the fly for a particular viewer, without needing to do anything to the home tool. To facilitate this, we change the default value for `visible_only` to `None`, and only check this default value if it wasn't definitively specified.