### PR TITLE
Keep local setting from overriding dark theme default

### DIFF
--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -29,7 +29,6 @@ if "AWS_EBS_URL" in os.environ:
 
 logger = setup_logger("LAYOUT")
 
-
 @solara.component
 def BaseLayout(
     local_state: Optional[Reactive[BaseLocalState]] = None,
@@ -233,6 +232,8 @@ def BaseLayout(
                         "voice", voice
                     ),
                 )
+
+            solara.lab.theme.dark = True
 
             solara.lab.ThemeToggle(
                 on_icon="mdi-brightness-4",


### PR DESCRIPTION
Per our meeting today, explicitly set dark theme so the ThemeToggle component doesn't override with the user's system setting. This will close https://github.com/cosmicds/hubbleds/issues/806