### PR TITLE
small adjustment to scaffold alert layout

### DIFF
--- a/src/cosmicds/vue_components/ScaffoldAlert.vue
+++ b/src/cosmicds/vue_components/ScaffoldAlert.vue
@@ -54,12 +54,11 @@
         </v-col>
         <v-col
           v-else
-          xl="8"
-          sm="6"
+          cols="5"
           class="shrink"
         >
           <div
-            style="border-left: solid 3px #FFD740; padding-left: 10px;"
+            style="border-right: solid 3px #FFD740; padding-right: 10px;"
           >
             <slot name="back-content" class="guideline-button"></slot>
           </div>
@@ -87,7 +86,7 @@
         </v-col>
         <v-col
           v-else
-          cols="6"
+          cols="5"
           class="shrink"
         >
           <div


### PR DESCRIPTION
This goes with an update in https://github.com/cosmicds/hubbleds/pull/883
<img width="1192" alt="Screenshot 2025-03-20 at 6 09 16 PM" src="https://github.com/user-attachments/assets/7caeb4de-1ae0-4431-bfcb-c22506dbaf22" />

Without this change, the text at the bottom of the guideline wraps and is pretty much impossible to parse. It's still hard, but I think it's an improvement?
<img width="1152" alt="Screenshot 2025-03-20 at 6 07 10 PM" src="https://github.com/user-attachments/assets/1e772d15-2197-4e0b-8b75-8d87a6d47987" />
