### PR TITLE
Undo forcing dark mode start that breaks light mode

### DIFF
--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -233,8 +233,6 @@ def BaseLayout(
                     ),
                 )
 
-            solara.lab.theme.dark = True
-
             solara.lab.ThemeToggle(
                 on_icon="mdi-brightness-4",
                 off_icon="mdi-brightness-4",


### PR DESCRIPTION
This reverts #371 which inadvertently caused https://github.com/cosmicds/hubbleds/issues/904.

We'll need to create our own version of the solara theming component to handle things in a more flexible way.