### PR TITLE
Allow toggling of team interface and debug mode

### DIFF
--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -316,7 +316,7 @@ def BaseLayout(
                         children=["mdi-account-circle"],
                         color="var(--success-dark)",
                     )
-                    solara.Text(f"ID: {GLOBAL_STATE.value.student.id}", style={"padding-right": "10px"})
+                    solara.Text(f"Student ID: {GLOBAL_STATE.value.student.id}", style={"padding-right": "10px"})
                     rv.Divider(vertical=True, class_="mx-2")
                     logout_button = rv.Btn(
                         v_on="tooltip.on",

--- a/src/cosmicds/state.py
+++ b/src/cosmicds/state.py
@@ -1,5 +1,5 @@
 import os
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from functools import cached_property
 from glue_jupyter import JupyterApplication
 from glue.core import DataCollection, Session
@@ -18,6 +18,29 @@ if 'CDS_DISABLE_DB' in os.environ:
 else:
     print("Database updates enabled.")
 
+debug_mode_init = False
+print("****Checking for debug mode...")
+# CDS_DEBUG_MODE must exist, and have the value 'true' to enable debug mode
+if 'CDS_DEBUG_MODE' in os.environ:
+    # check if it has a value and if it True
+    cds_debug_mode = os.getenv("CDS_DEBUG_MODE")
+    if cds_debug_mode.lower() == 'true':
+        print("****Debug mode enabled.")
+        debug_mode_init = True
+else:
+    print("****Debug mode disabled.")
+
+show_team_interface_init = False
+# CDS_SHOW_TEAM_INTERFACE must exist, and have the value 'true' to enable team interface
+print("****Checking for team interface...")
+if 'CDS_SHOW_TEAM_INTERFACE' in os.environ:
+    # check if it has a value and if it True
+    cds_show_team_interface = os.getenv("CDS_SHOW_TEAM_INTERFACE")
+    if cds_show_team_interface.lower() == 'true':
+        print("****Team interface enabled.")
+        show_team_interface_init = True
+else:
+    print("****Team interface disabled.")
 
 class BaseState(BaseModel):
     def as_dict(self):
@@ -44,7 +67,7 @@ class Speech(BaseModel):
 
 
 class BaseLocalState(BaseState):
-    debug_mode: bool = True
+    debug_mode: bool = Field(debug_mode_init, exclude=True)
     title: str
     story_id: str
     piggybank_total: int = 0
@@ -58,7 +81,7 @@ class GlobalState(BaseState):
     student: Student = Student()
     classroom: Classroom = Classroom()
     update_db: bool = update_db_init
-    show_team_interface: bool = False
+    show_team_interface: bool = Field(show_team_interface_init, exclude=True)
     allow_advancing: bool = True
     speech: Speech = Speech()
 

--- a/src/cosmicds/state.py
+++ b/src/cosmicds/state.py
@@ -19,28 +19,26 @@ else:
     print("Database updates enabled.")
 
 debug_mode_init = False
-print("****Checking for debug mode...")
 # CDS_DEBUG_MODE must exist, and have the value 'true' to enable debug mode
 if 'CDS_DEBUG_MODE' in os.environ:
     # check if it has a value and if it True
     cds_debug_mode = os.getenv("CDS_DEBUG_MODE")
     if cds_debug_mode.lower() == 'true':
-        print("****Debug mode enabled.")
+        print("Debug mode enabled.")
         debug_mode_init = True
 else:
-    print("****Debug mode disabled.")
+    print("Debug mode disabled.")
 
 show_team_interface_init = False
 # CDS_SHOW_TEAM_INTERFACE must exist, and have the value 'true' to enable team interface
-print("****Checking for team interface...")
 if 'CDS_SHOW_TEAM_INTERFACE' in os.environ:
     # check if it has a value and if it True
     cds_show_team_interface = os.getenv("CDS_SHOW_TEAM_INTERFACE")
     if cds_show_team_interface.lower() == 'true':
-        print("****Team interface enabled.")
+        print("Team interface enabled.")
         show_team_interface_init = True
 else:
-    print("****Team interface disabled.")
+    print("Team interface disabled.")
 
 class BaseState(BaseModel):
     def as_dict(self):

--- a/src/cosmicds/state.py
+++ b/src/cosmicds/state.py
@@ -78,7 +78,7 @@ class GlobalState(BaseState):
     loading_status_message: str = ""
     student: Student = Student()
     classroom: Classroom = Classroom()
-    update_db: bool = update_db_init
+    update_db: bool = Field(update_db_init, exclude=True)
     show_team_interface: bool = Field(show_team_interface_init, exclude=True)
     allow_advancing: bool = True
     speech: Speech = Speech()

--- a/src/cosmicds/vue_components/ScaffoldAlert.vue
+++ b/src/cosmicds/vue_components/ScaffoldAlert.vue
@@ -32,7 +32,7 @@
               ref="back"
               @click="() => { $emit('back'); }"
             >
-              back
+              {{ backText }} 
             </v-btn>
           </div>
         </v-col>
@@ -86,7 +86,7 @@
         </v-col>
         <v-col
           v-else
-          cols="5"
+          cols="6"
           class="shrink"
         >
           <div
@@ -176,6 +176,10 @@ module.exports = {
     headerText: {
       type: [String, Function],
       default: null
+    },
+    backText: {
+      type: String,
+      default: "back"
     },
     nextText: {
       type: String,


### PR DESCRIPTION
This sets `show_team_interface` and `debug_mode` to be false by default. 

Going forward, we can add `CDS_SHOW_TEAM_INTERFACE=true` and `CDS_DEBUG_MOD=true` to the command line incantation to run with the team interface and debug mode on locally.

~We'll also need to set up the deployed demo to set those environment variables to true - we should probably do that before we merge this - else the jump buttons will go away.~

ETA: There is just 1 demo branch button that would get hidden if this merges and [this PR](https://github.com/cosmicds/hubbleds/pull/941) will fix that.