### PR TITLE
Base layout changes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,9 +57,8 @@ install_requires =
     ipyvuetify
     numpy<2.0.0
     reacton
-    solara==1.42.0
-    solara-enterprise==1.42.0
-    solara-ui @ git+https://github.com/nmearl/solara.git@v1.42
+    solara==1.44.1
+    solara-enterprise==1.44.1
     traitlets
 
 [options.packages.find]

--- a/src/cosmicds/components/breakpoint_watcher/BreakpointWatcher.vue
+++ b/src/cosmicds/components/breakpoint_watcher/BreakpointWatcher.vue
@@ -1,0 +1,39 @@
+<script>
+export default {
+  name: "BreakpointWatcher",
+  data() {
+    return {
+      previousBreakpoint: null,
+      currentBreakpoint: null,
+    }
+  },
+  mounted() {
+    window.addEventListener("resize", this.onResize);
+    this.onResize();
+  },
+  unmounted() {
+    window.removeEventListener("resize", this.onResize);
+  },
+  methods: {
+    onResize() {
+      const h = window.innerHeight
+      const w = window.innerWidth
+      const bp = this.$vuetify.breakpoint.name
+
+      if (this.previousBreakpoint !== bp) {
+        this.previousBreakpoint = this.currentBreakpoint
+        this.currentBreakpoint = bp
+
+        this.set_breakpoint_info({
+          height: h,
+          width: w,
+          breakpoint: bp,
+        })
+      }
+    }
+  },
+}
+</script>
+
+<template>
+</template>

--- a/src/cosmicds/components/breakpoint_watcher/breakpoint_watcher.py
+++ b/src/cosmicds/components/breakpoint_watcher/breakpoint_watcher.py
@@ -1,0 +1,10 @@
+from typing import Callable
+
+import solara
+
+
+@solara.component_vue("BreakpointWatcher.vue")
+def BreakpointWatcher(
+    event_set_breakpoint_info: Callable[[dict], None] = None,
+):
+    pass

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -81,34 +81,41 @@ def BaseLayout(
 
     solara.use_memo(_load_from_cache)
 
-    if force_demo:
-        logger.info("Loading app in demo mode.")
-        auth.user.set(
-            {
-                "userinfo": {
-                    "cds/name": "Demo User",
-                    "cds/email": "cosmicds@cfa.harvard.edu",
-                    "cds/picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
-                    "nickname": "cosmicds",
-                    "name": "Demo User",
-                    "picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
-                    "updated_at": "2025-02-06T17:47:34.507Z",
-                    "email": "cosmicds@cfa.harvard.edu",
-                    "email_verified": True,
+    def _check_demo_mode():
+        if force_demo:
+            logger.info("Loading app in demo mode.")
+            auth.user.set(
+                {
+                    "userinfo": {
+                        "cds/name": "Demo User",
+                        "cds/email": "cosmicds@cfa.harvard.edu",
+                        "cds/picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
+                        "nickname": "cosmicds",
+                        "name": "Demo User",
+                        "picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
+                        "updated_at": "2025-02-06T17:47:34.507Z",
+                        "email": "cosmicds@cfa.harvard.edu",
+                        "email_verified": True,
+                    }
                 }
-            }
-        )
-        class_code.set("215")
+            )
+            class_code.set("215")
 
-    if bool(auth.user.value):
-        if BASE_API.user_exists:
-            BASE_API.load_user_info(story_name, GLOBAL_STATE)
-        elif bool(class_code.value):
-            BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
-        else:
-            logger.error("User is authenticated, but does not exist.")
-            solara.use_router().push(auth.get_logout_url())
-    else:
+    solara.use_memo(_check_demo_mode, dependencies=[])
+
+    def _query_user_info():
+        if bool(auth.user.value):
+            if BASE_API.user_exists:
+                BASE_API.load_user_info(story_name, GLOBAL_STATE)
+            elif bool(class_code.value):
+                BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
+            else:
+                logger.error("User is authenticated, but does not exist.")
+                solara.use_router().push(auth.get_logout_url())
+
+    solara.use_memo(_query_user_info, dependencies=[auth.user.value])
+
+    if not bool(auth.user.value):
         logger.info("User has not authenticated.")
         BASE_API.clear_user(GLOBAL_STATE)
 

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -181,21 +181,6 @@ def BaseLayout(
 
         rv.Spacer()
 
-        with rv.Chip(class_="ma-2 piggy-chip"):
-
-            if local_state is not None:
-                # TODO: Check that this doesn't make solara render the whole
-                #  app. if it does, move the chip into its own component.
-                solara.Text(f"{local_state.value.piggybank_total} Points")
-
-            rv.Icon(
-                class_="ml-2",
-                children=["mdi-piggy-bank"],
-                color="var(--success-dark)",
-            )
-
-        rv.Divider(vertical=True, class_="mx-2")
-
         with TooltipMenu(
             v_model=speech_menu.value,
             icon="mdi-tune-vertical",
@@ -233,6 +218,21 @@ def BaseLayout(
             enforce_default=True,
         )
 
+        rv.Divider(vertical=True, class_="mx-2")
+
+        with rv.Chip(class_="ma-2 piggy-chip"):
+
+            if local_state is not None:
+                # TODO: Check that this doesn't make solara render the whole
+                #  app. if it does, move the chip into its own component.
+                solara.Text(f"{local_state.value.piggybank_total} Points")
+
+            rv.Icon(
+                class_="ml-2",
+                children=["mdi-piggy-bank"],
+                color="var(--success-dark)",
+            )
+
     with rv.NavigationDrawer(
         v_model=drawer.value,
         on_v_model=drawer.set,
@@ -265,7 +265,7 @@ def BaseLayout(
                                                     ),
                                                     rv.Html(
                                                         tag="h4",
-                                                        children=f"{GLOBAL_STATE.value.student.id}",
+                                                        children=f"Student ID: {GLOBAL_STATE.value.student.id}",
                                                     ),
                                                 ],
                                             )

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -17,6 +17,7 @@ from reacton import ipyvue
 
 from .state import GLOBAL_STATE, BaseLocalState, Speech
 from .remote import BASE_API
+from .components.breakpoint_watcher.breakpoint_watcher import BreakpointWatcher
 from cosmicds import load_custom_vue_components
 from cosmicds.utils import get_session_id
 from cosmicds.components.login import Login
@@ -42,11 +43,11 @@ def BaseLayout(
     force_demo: bool = False,
 ):
     router = solara.use_router()
-
     route_current, routes_current_level = solara.use_route(peek=True)
     route_index = routes_current_level.index(route_current)
 
     selected_link = solara.use_reactive(route_index)
+    stu_info_panel = solara.use_reactive([0])
 
     def on_selected_link_change(new, old):
         logger.info(f"Selected link changed from {old} to {new}")
@@ -60,6 +61,12 @@ def BaseLayout(
 
     debug_menu = solara.use_reactive(False)
     speech_menu = solara.use_reactive(False)
+
+    # Set up a watcher for vue break_point events
+    break_point = solara.use_reactive("")
+    BreakpointWatcher(
+        event_set_breakpoint_info=lambda event: break_point.set(event["breakpoint"])
+    )
 
     def _component_setup():
         # Custom vue-only components have to be registered in the Page element
@@ -84,41 +91,34 @@ def BaseLayout(
 
     solara.use_memo(_load_from_cache)
 
-    def _check_demo_mode():
-        if force_demo:
-            logger.info("Loading app in demo mode.")
-            auth.user.set(
-                {
-                    "userinfo": {
-                        "cds/name": "Demo User",
-                        "cds/email": "cosmicds@cfa.harvard.edu",
-                        "cds/picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
-                        "nickname": "cosmicds",
-                        "name": "Demo User",
-                        "picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
-                        "updated_at": "2025-02-06T17:47:34.507Z",
-                        "email": "cosmicds@cfa.harvard.edu",
-                        "email_verified": True,
-                    }
+    if force_demo:
+        logger.info("Loading app in demo mode.")
+        auth.user.set(
+            {
+                "userinfo": {
+                    "cds/name": "Demo User",
+                    "cds/email": "cosmicds@cfa.harvard.edu",
+                    "cds/picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
+                    "nickname": "cosmicds",
+                    "name": "Demo User",
+                    "picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
+                    "updated_at": "2025-02-06T17:47:34.507Z",
+                    "email": "cosmicds@cfa.harvard.edu",
+                    "email_verified": True,
                 }
-            )
-            class_code.set("215")
+            }
+        )
+        class_code.set("215")
 
-    solara.use_memo(_check_demo_mode, dependencies=[])
-
-    def _query_user_info():
-        if bool(auth.user.value):
-            if BASE_API.user_exists:
-                BASE_API.load_user_info(story_name, GLOBAL_STATE)
-            elif bool(class_code.value):
-                BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
-            else:
-                logger.error("User is authenticated, but does not exist.")
-                solara.use_router().push(auth.get_logout_url())
-
-    solara.use_memo(_query_user_info, dependencies=[auth.user.value])
-
-    if not bool(auth.user.value):
+    if bool(auth.user.value):
+        if BASE_API.user_exists:
+            BASE_API.load_user_info(story_name, GLOBAL_STATE)
+        elif bool(class_code.value):
+            BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
+        else:
+            logger.error("User is authenticated, but does not exist.")
+            solara.use_router().push(auth.get_logout_url())
+    else:
         logger.info("User has not authenticated.")
         BASE_API.clear_user(GLOBAL_STATE)
 
@@ -148,286 +148,264 @@ def BaseLayout(
 
     drawer = solara.use_reactive(None)
 
-    with solara.Column(style={"height": "100vh"}) as main:
-        with rv.AppBar(
-            elevate_on_scroll=False, app=True, flat=True, class_="cosmicds-appbar"
-        ):
+    with rv.AppBar(
+        elevate_on_scroll=False,
+        app=True,
+        flat=True,
+        clipped_left=True,
+        class_="cosmicds-appbar",
+    ):
+        nav_icon = rv.AppBarNavIcon(v_on="tooltip.on")
+        ipyvue.use_event(nav_icon, "click", lambda *args: drawer.set(not drawer.value))
 
-            if not drawer.value:
-                # create a hamburger menu to show nav
-                rv.Tooltip(
-                    bottom=True,
-                    v_slots=[
-                        {
-                            "name": "activator",
-                            "variable": "tooltip",
-                            "children": [
-                                solara.IconButton(
-                                    v_on="tooltip.on",
-                                    icon_name=(
-                                        "mdi-close" if drawer.value else "mdi-menu"
-                                    ),
-                                    on_click=lambda: drawer.set(not drawer.value),
-                                )
-                            ],
-                        }
+        rv.Tooltip(
+            bottom=True,
+            v_slots=[
+                {
+                    "name": "activator",
+                    "variable": "tooltip",
+                    "children": [
+                        nav_icon,
                     ],
-                    children=[
-                        "Close Navigation" if drawer.value else "Open Navigation"
-                    ],
-                )
+                }
+            ],
+            children=["Close Navigation" if drawer.value else "Open Navigation"],
+        )
 
-            rv.Html(tag="h2", children=[f"{story_title}"])
-            rv.Html(tag="h3", children=["Cosmic Data Stories"], class_="ml-4 app-title")
+        rv.Html(tag="h2", children=["Hubble's Law"], class_="pl-5")
+        # rv.Html(
+        #     tag="h4",
+        #     children=["Cosmic Data Story"],
+        #     class_="ml-8 app-title",
+        # )
 
-            rv.Spacer()
+        rv.Spacer()
 
-            with TooltipMenu(
-                v_model=speech_menu.value,
-                icon="mdi-tune-vertical",
-                tooltip="Speech Settings",
-                bottom=True,
-                offset_y=True,
-                close_on_content_click=False,
-            ):
-                initial_settings = GLOBAL_STATE.value.speech.model_dump()
+        with rv.Chip(class_="ma-2 piggy-chip"):
 
-                def update_speech_property(prop, value):
-                    settings = speech.value.model_copy()
-                    setattr(settings, prop, value)
-                    speech.set(settings)
+            if local_state is not None:
+                # TODO: Check that this doesn't make solara render the whole
+                #  app. if it does, move the chip into its own component.
+                solara.Text(f"{local_state.value.piggybank_total} Points")
 
-                SpeechSettings(
-                    initial_state=initial_settings,
-                    event_autoread_changed=lambda read: update_speech_property(
-                        "autoread", read
-                    ),
-                    event_pitch_changed=lambda pitch: update_speech_property(
-                        "pitch", pitch
-                    ),
-                    event_rate_changed=lambda rate: update_speech_property(
-                        "rate", rate
-                    ),
-                    event_voice_changed=lambda voice: update_speech_property(
-                        "voice", voice
-                    ),
-                )
-
-            ThemeToggle(
-                on_icon="mdi-brightness-4",  # dark mode icon
-                off_icon="mdi-brightness-4",  # light mode icon
-                enable_auto=False,
-                default_theme="dark",
-                enforce_default=True,
+            rv.Icon(
+                class_="ml-2",
+                children=["mdi-piggy-bank"],
+                color="var(--success-dark)",
             )
 
-            with rv.Chip(class_="ma-2 piggy-chip"):
+        rv.Divider(vertical=True, class_="mx-2")
 
-                if local_state is not None:
-                    # check that this doesn't make solara render the whole app. if it does, move the chip into its own component.
-                    solara.Text(f"{local_state.value.piggybank_total} Points")
-
-                rv.Icon(
-                    class_="ml-2",
-                    children=["mdi-piggy-bank"],
-                    color="var(--success-dark)",
-                )
-
-            with TooltipMenu(
-                v_model=debug_menu.value,
-                icon="mdi-account",
-                tooltip="Student Info",
-                bottom=True,
-                offset_y=True,
-                close_on_content_click=False,
-            ):
-                with rv.Card(width=250):
-                    with rv.CardText():
-                        rv.TextField(
-                            value=f"{GLOBAL_STATE.value.student.id}",
-                            label="Student ID No.",
-                            readonly=True,
-                            outlined=True,
-                            dense=True,
-                        )
-                        rv.TextField(
-                            value=f"{BASE_API.hashed_user}",
-                            label="Anonymized ID",
-                            readonly=True,
-                            outlined=True,
-                            dense=True,
-                        )
-
-        with rv.NavigationDrawer(
-            v_model=drawer.value, on_v_model=drawer.set, app=True, class_="px-0 mx-0"
+        with TooltipMenu(
+            v_model=speech_menu.value,
+            icon="mdi-tune-vertical",
+            tooltip="Speech Settings",
+            bottom=True,
+            offset_y=True,
+            close_on_content_click=False,
         ):
-            with rv.Col(
-                class_="d-flex flex-column px-0 mx-0",
-                style_="height:100%; align-items: stretch; justify-content: flex-start;",
-            ):
-                with rv.ListItem(
-                    class_="nav-top justify-space-between align-center",
-                    style_="flex: 0 0 auto; text-align: right",
-                ):
-                    # with rv.ListItemContent():
-                    #     # We access the modified token information first, if that
-                    #     #  does not exist, we fall back to the default parameters
-                    #     #  returned by the `display_info` property
-                    #     rv.ListItemTitle(
-                    #         class_="text-h6", children=[f"{display_info.value['cds/name']}"]
-                    #     )
-                    #     rv.ListItemSubtitle(children=[f"{display_info.value['cds/email']}"])
+            initial_settings = GLOBAL_STATE.value.speech.model_dump()
 
-                    solara.Text(
-                        "Stage Navigation",
-                        style={"font-size": "20px", "font-weight": "bold"},
-                    )
-                    rv.Tooltip(
-                        bottom=True,
-                        v_slots=[
-                            {
-                                "name": "activator",
-                                "variable": "tooltip",
-                                "children": [
-                                    solara.IconButton(
-                                        v_on="tooltip.on",
-                                        icon_name="mdi-close",
-                                        on_click=lambda: drawer.set(not drawer.value),
-                                    )
-                                ],
-                            }
-                        ],
+            def update_speech_property(prop, value):
+                settings = speech.value.model_copy()
+                setattr(settings, prop, value)
+                speech.set(settings)
+
+            SpeechSettings(
+                initial_state=initial_settings,
+                event_autoread_changed=lambda read: update_speech_property(
+                    "autoread", read
+                ),
+                event_pitch_changed=lambda pitch: update_speech_property(
+                    "pitch", pitch
+                ),
+                event_rate_changed=lambda rate: update_speech_property("rate", rate),
+                event_voice_changed=lambda voice: update_speech_property(
+                    "voice", voice
+                ),
+            )
+
+        ThemeToggle(
+            on_icon="mdi-brightness-4",  # dark mode icon
+            off_icon="mdi-brightness-4",  # light mode icon
+            enable_auto=False,
+            default_theme="dark",
+            enforce_default=True,
+        )
+
+    with rv.NavigationDrawer(
+        v_model=drawer.value,
+        on_v_model=drawer.set,
+        app=True,
+        clipped=True,
+        v_slots=[
+            {
+                "name": "append",
+                "variable": "btm",
+                "children": [
+                    rv.ExpansionPanels(
+                        v_model=stu_info_panel.value,
+                        on_v_model=stu_info_panel.set,
+                        flat=True,
+                        tile=True,
+                        style_="padding-right: 1px;",
                         children=[
-                            "Close Navigation" if drawer.value else "Open Navigation"
+                            rv.ExpansionPanel(
+                                class_="pa-0 ma-0",
+                                children=[
+                                    rv.ExpansionPanelHeader(
+                                        class_="mx-2 my-0",
+                                        children=[
+                                            rv.Row(
+                                                class_="flex align-center",
+                                                children=[
+                                                    rv.Icon(
+                                                        children="mdi-account",
+                                                        class_="mr-4",
+                                                    ),
+                                                    rv.Html(
+                                                        tag="h4",
+                                                        children="Student Info",
+                                                    ),
+                                                ],
+                                            )
+                                        ],
+                                    ),
+                                    rv.ExpansionPanelContent(
+                                        children=[
+                                            rv.TextField(
+                                                value=f"{display_info.value['cds/email']}",
+                                                label="Email",
+                                                readonly=True,
+                                                outlined=True,
+                                                dense=True,
+                                            ),
+                                            rv.TextField(
+                                                value=f"{GLOBAL_STATE.value.student.id}",
+                                                label="Student ID No.",
+                                                readonly=True,
+                                                outlined=True,
+                                                dense=True,
+                                            ),
+                                            rv.TextField(
+                                                value=f"{BASE_API.hashed_user}",
+                                                label="Anonymized ID",
+                                                readonly=True,
+                                                outlined=True,
+                                                dense=True,
+                                                hide_details=True,
+                                            ),
+                                        ]
+                                    ),
+                                ],
+                            )
                         ],
                     )
-
-                rv.Divider()
-
-                with rv.List(nav=True, class_="px-0"):
-                    with rv.ListItemGroup(
-                        v_model=selected_link.value,
-                    ):
-
-                        def _change_local_url(path, location):
-                            if path != "/":
-                                router.push(f"{router.root_path}{path}")
-                            else:
-                                location.pathname = settings.main.base_url
-
-                        for i, route in enumerate(routes_current_level):
-                            disabled = False
-                            if local_state is not None:
-                                disabled = (
-                                    local_state.value.max_route_index is not None
-                                    and i > local_state.value.max_route_index
-                                )
-                            with rv.ListItem(
-                                disabled=disabled,
-                                inactive=disabled,
-                                link=True,
-                                class_="px-0 mx-0",
-                            ) as list_item:
-                                with rv.ListItemIcon(class_="px-0 mx-4"):
-                                    rv.Icon(children=f"mdi-numeric-{i}-circle")
-
-                                with rv.ListItemContent(
-                                    style_="white-space: normal; overflow: visible; text-overflow: clip;",
-                                    class_="px-0 mx-0",
-                                ):
-                                    rv.ListItemTitle(
-                                        children=f"{route.label if route.path != '/' else 'Introduction'}"
-                                    )
-
-                            solara.v.use_event(
-                                list_item,
-                                "click",
-                                lambda *args, path=solara.resolve_path(
-                                    route
-                                ), location=solara.use_context(
-                                    solara.routing._location_context
-                                ): _change_local_url(
-                                    path, location
-                                ),
-                            )
-
-                rv.Spacer()
-                rv.Divider()
-                with rv.Row(
-                    class_="px-0 ma-2",
-                    style_="flex-grow: 1; flex: 0 0 auto; justify-content: space-evenly; align-items: center;",
-                ):
-                    rv.Icon(
-                        class_="mx-2",
-                        children=["mdi-account-circle"],
-                        color="var(--success-dark)",
-                    )
-                    solara.Text(
-                        f"Student ID: {GLOBAL_STATE.value.student.id}",
-                        style={"padding-right": "10px"},
-                    )
-                    # rv.Divider(vertical=True, class_="mx-2")
-                    # logout_button = rv.Btn(
-                    #     v_on="tooltip.on",
-                    #     href=auth.get_logout_url(), icon=True,
-                    #     children=[rv.Icon(children=["mdi-logout"])]
-                    #     )
-
-                    # rv.Tooltip(
-                    #     right=True,
-                    #     v_slots = [{
-                    #         "name": "activator",
-                    #         "variable": "tooltip",
-                    #         "children":[logout_button]
-                    #         }],
-                    #         children=["Logout"]
-                    #         )
-
-                #
-
-        with rv.Content(class_="solara-content-main", style_="height: 100%"):
-            with rv.Container(
-                # children=children,
-                class_="solara-container-main",
-                style_="height: 100%; width: 100%; overflow: auto;",
-                fluid=True,
-            ):
-                rv.Container(
-                    children=children, style_="height: 100%; width: 100%", fluid=False
-                )
-
-        with rv.Footer(
-            class_="text-center align-items",
-            padless=True,
-            app=True,
-            inset=True,
+                ],
+            }
+        ],
+    ) as navigation_drawer:
+        with rv.List(
+            nav=True,
         ):
-            with rv.Card(
-                flat=True, tile=True, class_="cosmicds-footer", style_="width: 100%;"
+            if break_point.value in ["xs", "sm", "md"]:
+                with rv.Row(class_="flex justify-end pb-2 ml-0"):
+                    solara.IconButton(
+                        "mdi-close",
+                        on_click=lambda: drawer.set(False),
+                        right=True,
+                        x_small=True,
+                    )
+
+            with rv.ListItemGroup(
+                v_model=selected_link.value,
             ):
-                rv.Divider()
 
-                with solara.Columns([2, 10]):
-                    with solara.Column(classes=["cosmicds-footer"]):
-                        with rv.CardText():
-                            solara.HTML(
-                                unsafe_innerHTML=rf"""
-                                {datetime.date.today().year} - <b>CosmicDS</b>
-                                """,
-                                style="font-size: 18px;",
+                def _change_local_url(path, location):
+                    if path != "/":
+                        router.push(f"{router.root_path}{path}")
+                    else:
+                        location.pathname = settings.main.base_url
+
+                for i, route in enumerate(routes_current_level):
+                    disabled = False
+                    if local_state is not None:
+                        disabled = (
+                            local_state.value.max_route_index is not None
+                            and i > local_state.value.max_route_index
+                        )
+
+                    with rv.ListItem(
+                        disabled=disabled,
+                        inactive=disabled,
+                        link=True,
+                    ) as list_item:
+                        with rv.ListItemIcon(class_="mr-4"):
+                            rv.Icon(children=f"mdi-numeric-{i}-circle")
+
+                        with rv.ListItemContent(
+                            style_="white-space: normal; overflow: visible; text-overflow: clip;",
+                            class_="px-0 mx-0",
+                        ):
+                            rv.ListItemTitle(
+                                children=f"{route.label if route.path != '/' else 'Introduction'}"
                             )
 
-                    with solara.Column(classes=["cosmicds-footer"]):
-                        with rv.CardText():
-                            solara.HTML(
-                                tag="span",
-                                unsafe_innerHTML="""
-                            The material contained on this website is based upon 
-                            work supported by NASA under award No. 80NSSC21M0002. 
-                            Any opinions, findings, and conclusions or 
-                            recommendations expressed in this material are those of 
-                            the author(s) and do not necessarily reflect the views 
-                            of the National Aeronautics and Space Administration.
+                    solara.v.use_event(
+                        list_item,
+                        "click",
+                        lambda *args, path=solara.resolve_path(
+                            route
+                        ), location=solara.use_context(
+                            solara.routing._location_context
+                        ): _change_local_url(
+                            path, location
+                        ),
+                    )
+
+    with rv.Content(class_="solara-content-main", style_="height: 100%"):
+        with rv.Container(
+            # children=children,
+            class_="solara-container-main",
+            style_="height: 100%; width: 100%; overflow: auto;",
+            fluid=True,
+        ):
+            rv.Container(
+                children=children, style_="height: 100%; width: 100%", fluid=False
+            )
+
+    with rv.Footer(
+        class_="text-center align-items",
+        padless=True,
+        app=True,
+        inset=True,
+    ):
+        with rv.Card(
+            flat=True, tile=True, class_="cosmicds-footer", style_="width: 100%;"
+        ):
+            rv.Divider()
+
+            with solara.Columns([2, 10]):
+                with solara.Column(classes=["cosmicds-footer"]):
+                    with rv.CardText():
+                        solara.HTML(
+                            unsafe_innerHTML=rf"""
+                            {datetime.date.today().year} - <b>CosmicDS</b>
                             """,
-                                style="font-size: 12px; line-height: 12px",
-                            )
+                            style="font-size: 18px;",
+                        )
+
+                with solara.Column(classes=["cosmicds-footer"]):
+                    with rv.CardText():
+                        solara.HTML(
+                            tag="span",
+                            unsafe_innerHTML="""
+                        The material contained on this website is based upon 
+                        work supported by NASA under award No. 80NSSC21M0002. 
+                        Any opinions, findings, and conclusions or 
+                        recommendations expressed in this material are those of 
+                        the author(s) and do not necessarily reflect the views 
+                        of the National Aeronautics and Space Administration.
+                        """,
+                            style="font-size: 12px; line-height: 12px",
+                        )

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -265,7 +265,7 @@ def BaseLayout(
                                                     ),
                                                     rv.Html(
                                                         tag="h4",
-                                                        children="Student Info",
+                                                        children=f"{GLOBAL_STATE.value.student.id}",
                                                     ),
                                                 ],
                                             )
@@ -273,20 +273,6 @@ def BaseLayout(
                                     ),
                                     rv.ExpansionPanelContent(
                                         children=[
-                                            rv.TextField(
-                                                value=f"{display_info.value['cds/email']}",
-                                                label="Email",
-                                                readonly=True,
-                                                outlined=True,
-                                                dense=True,
-                                            ),
-                                            rv.TextField(
-                                                value=f"{GLOBAL_STATE.value.student.id}",
-                                                label="Student ID No.",
-                                                readonly=True,
-                                                outlined=True,
-                                                dense=True,
-                                            ),
                                             rv.TextField(
                                                 value=f"{BASE_API.hashed_user}",
                                                 label="Anonymized ID",

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -157,25 +157,30 @@ def BaseLayout(
                 # create a hamburger menu to show nav
                 rv.Tooltip(
                     bottom=True,
-                    v_slots=[{
-                        "name": "activator",
-                        "variable": "tooltip",
-                        "children": [
-                            solara.IconButton(
-                                v_on="tooltip.on",
-                                icon_name="mdi-close" if drawer.value else "mdi-menu",
-                                on_click=lambda: drawer.set(not drawer.value),
-                            )
-                        ]
-                    }],
-                    children=["Close Navigation" if drawer.value else "Open Navigation"]
+                    v_slots=[
+                        {
+                            "name": "activator",
+                            "variable": "tooltip",
+                            "children": [
+                                solara.IconButton(
+                                    v_on="tooltip.on",
+                                    icon_name=(
+                                        "mdi-close" if drawer.value else "mdi-menu"
+                                    ),
+                                    on_click=lambda: drawer.set(not drawer.value),
+                                )
+                            ],
+                        }
+                    ],
+                    children=[
+                        "Close Navigation" if drawer.value else "Open Navigation"
+                    ],
                 )
-            
+
             rv.Html(tag="h2", children=[f"{story_title}"])
             rv.Html(tag="h3", children=["Cosmic Data Stories"], class_="ml-4 app-title")
 
             rv.Spacer()
-
 
             with TooltipMenu(
                 v_model=speech_menu.value,
@@ -209,8 +214,8 @@ def BaseLayout(
                 )
 
             ThemeToggle(
-                on_icon="mdi-brightness-4", # dark mode icon
-                off_icon="mdi-brightness-4", # light mode icon
+                on_icon="mdi-brightness-4",  # dark mode icon
+                off_icon="mdi-brightness-4",  # light mode icon
                 enable_auto=False,
                 default_theme="dark",
                 enforce_default=True,
@@ -254,14 +259,16 @@ def BaseLayout(
                         )
 
         with rv.NavigationDrawer(
-
-            v_model=drawer.value,
-            on_v_model=drawer.set,
-            app=True,
-            class_="px-0 mx-0"
+            v_model=drawer.value, on_v_model=drawer.set, app=True, class_="px-0 mx-0"
         ):
-            with rv.Col(class_="d-flex flex-column px-0 mx-0", style_="height:100%; align-items: stretch; justify-content: flex-start;"):
-                with rv.ListItem(class_="nav-top justify-space-between align-center", style_="flex: 0 0 auto; text-align: right"):
+            with rv.Col(
+                class_="d-flex flex-column px-0 mx-0",
+                style_="height:100%; align-items: stretch; justify-content: flex-start;",
+            ):
+                with rv.ListItem(
+                    class_="nav-top justify-space-between align-center",
+                    style_="flex: 0 0 auto; text-align: right",
+                ):
                     # with rv.ListItemContent():
                     #     # We access the modified token information first, if that
                     #     #  does not exist, we fall back to the default parameters
@@ -271,31 +278,35 @@ def BaseLayout(
                     #     )
                     #     rv.ListItemSubtitle(children=[f"{display_info.value['cds/email']}"])
 
-                    solara.Text("Stage Navigation", style={"font-size": "20px", "font-weight": "bold"});
+                    solara.Text(
+                        "Stage Navigation",
+                        style={"font-size": "20px", "font-weight": "bold"},
+                    )
                     rv.Tooltip(
                         bottom=True,
-                        v_slots=[{
-                            "name": "activator",
-                            "variable": "tooltip",
-                            "children": [
-                                solara.IconButton(
-                                    v_on="tooltip.on",
-                                    icon_name="mdi-close",
-                                    on_click=lambda: drawer.set(not drawer.value),
-                                )
-                            ]
-                        }],
-                        children=["Close Navigation" if drawer.value else "Open Navigation"]
+                        v_slots=[
+                            {
+                                "name": "activator",
+                                "variable": "tooltip",
+                                "children": [
+                                    solara.IconButton(
+                                        v_on="tooltip.on",
+                                        icon_name="mdi-close",
+                                        on_click=lambda: drawer.set(not drawer.value),
+                                    )
+                                ],
+                            }
+                        ],
+                        children=[
+                            "Close Navigation" if drawer.value else "Open Navigation"
+                        ],
                     )
-
-
 
                 rv.Divider()
 
                 with rv.List(nav=True, class_="px-0"):
                     with rv.ListItemGroup(
                         v_model=selected_link.value,
-
                     ):
 
                         def _change_local_url(path, location):
@@ -311,11 +322,19 @@ def BaseLayout(
                                     local_state.value.max_route_index is not None
                                     and i > local_state.value.max_route_index
                                 )
-                            with rv.ListItem(disabled=disabled, inactive=disabled, link=True, class_="px-0 mx-0") as list_item::
+                            with rv.ListItem(
+                                disabled=disabled,
+                                inactive=disabled,
+                                link=True,
+                                class_="px-0 mx-0",
+                            ) as list_item:
                                 with rv.ListItemIcon(class_="px-0 mx-4"):
                                     rv.Icon(children=f"mdi-numeric-{i}-circle")
 
-                                with rv.ListItemContent(style_="white-space: normal; overflow: visible; text-overflow: clip;", class_="px-0 mx-0"):
+                                with rv.ListItemContent(
+                                    style_="white-space: normal; overflow: visible; text-overflow: clip;",
+                                    class_="px-0 mx-0",
+                                ):
                                     rv.ListItemTitle(
                                         children=f"{route.label if route.path != '/' else 'Introduction'}"
                                     )
@@ -323,22 +342,30 @@ def BaseLayout(
                             solara.v.use_event(
                                 list_item,
                                 "click",
-                                lambda *args,
-                                path=solara.resolve_path(route),
-                                location=solara.use_context(
+                                lambda *args, path=solara.resolve_path(
+                                    route
+                                ), location=solara.use_context(
                                     solara.routing._location_context
-                                ): _change_local_url(path, location),
+                                ): _change_local_url(
+                                    path, location
+                                ),
                             )
 
                 rv.Spacer()
                 rv.Divider()
-                with rv.Row(class_="px-0 ma-2", style_="flex-grow: 1; flex: 0 0 auto; justify-content: space-evenly; align-items: center;"):
+                with rv.Row(
+                    class_="px-0 ma-2",
+                    style_="flex-grow: 1; flex: 0 0 auto; justify-content: space-evenly; align-items: center;",
+                ):
                     rv.Icon(
                         class_="mx-2",
                         children=["mdi-account-circle"],
                         color="var(--success-dark)",
                     )
-                    solara.Text(f"Student ID: {GLOBAL_STATE.value.student.id}", style={"padding-right": "10px"})
+                    solara.Text(
+                        f"Student ID: {GLOBAL_STATE.value.student.id}",
+                        style={"padding-right": "10px"},
+                    )
                     # rv.Divider(vertical=True, class_="mx-2")
                     # logout_button = rv.Btn(
                     #     v_on="tooltip.on",
@@ -357,7 +384,6 @@ def BaseLayout(
                     #         )
 
                 #
-                                    )
 
         with rv.Content(class_="solara-content-main", style_="height: 100%"):
             with rv.Container(

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -125,11 +125,11 @@ class BaseAPI:
         local_state: Reactive[BaseLocalState],
         component_state: Reactive[BaseState],
     ) -> BaseState | None:
-        
+
         if not global_state.value.update_db:
             logger.info("Skipping retrieval of Component state.")
             return component_state.value
-        
+
         stage_json = (
             self.request_session.get(
                 f"{self.API_URL}/stage-state/{global_state.value.student.id}/"
@@ -162,7 +162,7 @@ class BaseAPI:
         if not global_state.value.update_db:
             logger.info("Skipping deletion of stage state.")
             return
-        
+
         r = self.request_session.delete(
             f"{self.API_URL}/stage-state/{global_state.value.student.id}/"
             f"{local_state.value.story_id}/{component_state.value.stage_id}"
@@ -191,7 +191,7 @@ class BaseAPI:
         self, global_state: Reactive[GlobalState], local_state: Reactive[BaseLocalState]
     ) -> BaseLocalState | None:
         if global_state.value.update_db:
-        
+
             story_json = (
                 self.request_session.get(
                     f"{self.API_URL}/story-state/{global_state.value.student.id}/"
@@ -213,14 +213,15 @@ class BaseAPI:
             logger.info("Skipping retrieval of Global and Local states.")
             story_json = {
                 "app": GlobalState(student=GLOBAL_STATE.value.student).model_dump(),
-                "story": type(local_state.value)(title=local_state.value.title, story_id=local_state.value.story_id).as_dict(),
+                "story": type(local_state.value)(
+                    title=local_state.value.title, story_id=local_state.value.story_id
+                ).as_dict(),
             }
 
         global_state_json = story_json.get("app", {})
         BaseAPI._update_state(global_state, global_state_json)
 
         local_state_json = story_json.get("story", {})
-        logger.debug(local_state_json)
         BaseAPI._update_state(local_state, local_state_json)
 
         logger.info("Updated local state from database.")
@@ -232,7 +233,7 @@ class BaseAPI:
         global_state: Reactive[GlobalState],
         local_state: Reactive[BaseLocalState],
     ):
-       raise NotImplementedError() 
+        raise NotImplementedError()
 
     @staticmethod
     def clear_user(state: Reactive[GlobalState]):


### PR DESCRIPTION
With the recent changes to the display user info and the navigation drawer, things were getting a tad misaligned and a bit spread out. I've made some minor changes that I think help to clean up the story chrome:

- No longer clip the App bar and have it extend across the top. Use the built-in navigation drawer toggle icon.
- Implement a `BreakpointWatcher` that notifies Solara when Vuetify has triggered a breakpoint change. This allows us to know when the navigation drawer has switched to floating. Doing so allows us to render a small "close" button only when the navigation drawer is floating.
- Revert the list back to the default formatting. I believe the changes were due to some stages escaping their `div`s, but we can fix that by adjusting the margins around the list item icons.
- Centralize the user info into a shelf that slides up from the bottom of the navigation drawer.
- Consequently, re-order the user score and user settings and visually distinguish their locations with a vertical divider


https://github.com/user-attachments/assets/4adf88c7-4efd-4a81-bf30-d256d63e794e

