### PR TITLE
Show Educator Demo Interface

### DIFF
--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -69,6 +69,7 @@ def BaseSetup(
     educator_mode = False
     if bool(auth.user.value):
         if BASE_API.is_educator:
+            force_demo = True
             educator_mode = True
             GLOBAL_STATE.value.update_db = False
             GLOBAL_STATE.value.show_team_interface = True

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -310,14 +310,14 @@ def BaseLayout(
                                                 dense=True,
                                                 hide_details=True,
                                             ),
-                                            rv.Divider(),
-                                            rv.Btn(
-                                                href=auth.get_logout_url(), icon=False, 
-                                                block=True, outlined=True,
-                                                class_="mt-2",
-                                                # children=[rv.Icon(children=["mdi-logout"])]
-                                                children=["Logout"],
-                                            ), 
+                                            # rv.Divider(),
+                                            # rv.Btn(
+                                            #     href=auth.get_logout_url(), icon=False, 
+                                            #     block=True, outlined=True,
+                                            #     class_="mt-2",
+                                            #     # children=[rv.Icon(children=["mdi-logout"])]
+                                            #     children=["Logout"],
+                                            # ), 
                                         ]
                                     ),
                                 ],

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -65,24 +65,49 @@ def BaseSetup(
                     state.set(cache[key])
 
     solara.use_memo(_load_from_cache, dependencies=[])
+    
+    educator_mode = False
+    if bool(auth.user.value):
+        if BASE_API.is_educator:
+            educator_mode = True
+            GLOBAL_STATE.value.update_db = False
+            GLOBAL_STATE.value.show_team_interface = True
+            GLOBAL_STATE.value.educator = True
 
     if force_demo:
         logger.info("Loading app in demo mode.")
-        auth.user.set(
+        if educator_mode:
+            auth.user.set(
             {
                 "userinfo": {
-                    "cds/name": "Demo User",
-                    "cds/email": "cosmicds@cfa.harvard.edu",
+                    "cds/name": "Demo Teacher",
+                    "cds/email": "demo_teacher@some.email",
                     "cds/picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
                     "nickname": "cosmicds",
-                    "name": "Demo User",
+                    "name": "Demo Teacher",
                     "picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
                     "updated_at": "2025-02-06T17:47:34.507Z",
-                    "email": "cosmicds@cfa.harvard.edu",
+                    "email": "demo_teacher@some.email",
                     "email_verified": True,
                 }
             }
         )
+        else:   
+            auth.user.set(
+                {
+                    "userinfo": {
+                        "cds/name": "Demo User",
+                        "cds/email": "cosmicds@cfa.harvard.edu",
+                        "cds/picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
+                        "nickname": "cosmicds",
+                        "name": "Demo User",
+                        "picture": "https://s.gravatar.com/avatar/d49c4a758d6e45538cd0fb4cd09e91eb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fco.png",
+                        "updated_at": "2025-02-06T17:47:34.507Z",
+                        "email": "cosmicds@cfa.harvard.edu",
+                        "email_verified": True,
+                    }
+                }
+            )
         class_code.set("215")
 
     if bool(auth.user.value):
@@ -177,7 +202,13 @@ def BaseLayout(
         #     children=["Cosmic Data Story"],
         #     class_="ml-8 app-title",
         # )
-
+        if GLOBAL_STATE.value.educator:
+            rv.Html(
+                tag="h3",
+                class_="ml-8 app-title",
+                children=["Educator Mode"],
+                style_="color: #8e8e8e; font-size: 1.5em; font-weight: bold;",
+            )
         rv.Spacer()
 
         with TooltipMenu(
@@ -280,6 +311,14 @@ def BaseLayout(
                                                 dense=True,
                                                 hide_details=True,
                                             ),
+                                            rv.Divider(),
+                                            rv.Btn(
+                                                href=auth.get_logout_url(), icon=False, 
+                                                block=True, outlined=True,
+                                                class_="mt-2",
+                                                # children=[rv.Icon(children=["mdi-logout"])]
+                                                children=["Logout"],
+                                            ), 
                                         ]
                                     ),
                                 ],

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -74,7 +74,7 @@ def BaseLayout(
         logger.info("Loaded custom vue files.")
         load_custom_vue_components()
 
-    solara.use_memo(_component_setup)
+    solara.use_memo(_component_setup, dependencies=[])
 
     # Attempt to load saved setup state
     def _load_from_cache():
@@ -89,7 +89,7 @@ def BaseLayout(
                 if key in cache:
                     state.set(cache[key])
 
-    solara.use_memo(_load_from_cache)
+    solara.use_memo(_load_from_cache, dependencies=[])
 
     if force_demo:
         logger.info("Loading app in demo mode.")
@@ -117,7 +117,8 @@ def BaseLayout(
             BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
         else:
             logger.error("User is authenticated, but does not exist.")
-            solara.use_router().push(auth.get_logout_url())
+            location = solara.use_context(solara.routing._location_context)
+            location.pathname = auth.get_logout_url()
     else:
         logger.info("User has not authenticated.")
         BASE_API.clear_user(GLOBAL_STATE)

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -211,20 +211,22 @@ class BaseAPI:
             )
 
             if story_json is None:
-                logger.error(
-                    "Failed to retrieve state for story `%s` for user `%s`.",
-                    local_state.value.story_id,
-                    global_state.value.student.id,
-                )
+                logger.error(f"Failed to retrieve state for story {local_state.value.story_id} for user {global_state.value.student.id}.")
                 return
 
         else:
             logger.info("Skipping retrieval of Global and Local states.")
             story_json = {
-                "app": GlobalState(student=GLOBAL_STATE.value.student).model_dump(),
+                "app": GlobalState(
+                    student=GLOBAL_STATE.value.student, 
+                    show_team_interface = GLOBAL_STATE.value.show_team_interface, 
+                    classroom = GLOBAL_STATE.value.classroom,
+                    educator = GLOBAL_STATE.value.educator,
+                    update_db = GLOBAL_STATE.value.update_db,
+                    ).model_dump(),
                 "story": type(local_state.value)(
                     title=local_state.value.title, story_id=local_state.value.story_id
-                ).as_dict(),
+                ).as_dict(), # type: ignore
             }
 
         global_state_json = story_json.get("app", {})

--- a/src/cosmicds/remote.py
+++ b/src/cosmicds/remote.py
@@ -51,6 +51,15 @@ class BaseAPI:
         r = self.request_session.get(f"{self.API_URL}/student/{self.hashed_user}")
         return r.json()["student"] is not None
 
+    
+    @property
+    def is_educator(self):
+        r = self.request_session.get(
+            f"{self.API_URL}/educators/{self.hashed_user}"
+        )
+        return r.json()["educator"] is not None
+    
+
     def update_class_size(self, state: Reactive[GlobalState]):
         class_id = state.value.classroom.class_info["id"]
         size_json = self.request_session.get(
@@ -126,7 +135,7 @@ class BaseAPI:
         component_state: Reactive[BaseState],
     ) -> BaseState | None:
 
-        if not global_state.value.update_db:
+        if not global_state.value.update_db or self.is_educator:
             logger.info("Skipping retrieval of Component state.")
             return component_state.value
 
@@ -159,7 +168,7 @@ class BaseAPI:
         local_state: Reactive[BaseLocalState],
         component_state: Reactive[BaseState],
     ):
-        if not global_state.value.update_db:
+        if not global_state.value.update_db or self.is_educator:
             logger.info("Skipping deletion of stage state.")
             return
 
@@ -190,7 +199,7 @@ class BaseAPI:
     def get_app_story_states(
         self, global_state: Reactive[GlobalState], local_state: Reactive[BaseLocalState]
     ) -> BaseLocalState | None:
-        if global_state.value.update_db:
+        if global_state.value.update_db and not self.is_educator:
 
             story_json = (
                 self.request_session.get(

--- a/src/cosmicds/state.py
+++ b/src/cosmicds/state.py
@@ -83,10 +83,6 @@ class GlobalState(BaseState):
     allow_advancing: bool = True
     speech: Speech = Speech()
     educator: bool = False
-    
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        print("====== GlobalState ======")
 
     @cached_property
     def _glue_app(self) -> JupyterApplication:

--- a/src/cosmicds/state.py
+++ b/src/cosmicds/state.py
@@ -82,6 +82,11 @@ class GlobalState(BaseState):
     show_team_interface: bool = Field(show_team_interface_init, exclude=True)
     allow_advancing: bool = True
     speech: Speech = Speech()
+    educator: bool = False
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        print("====== GlobalState ======")
 
     @cached_property
     def _glue_app(self) -> JupyterApplication:


### PR DESCRIPTION
Used the hashed identifier to determine if the user logging in is an educator, and if so show them the team interface. There is a companion PR on hubblds https://github.com/cosmicds/hubbleds/pull/960

Once it determines the user is an educator, it uses the demo student. In the database, I have duplicated the demo student as an educator so that when it checks again it will still see the user as an educator.

This roundabout was needed because the `GlobalState` can get reset or reinitialized, and will reset to default values (if they're not stored in the DB). Since I am trying to follow https://github.com/cosmicds/hubbleds/issues/951, we couldn't do that. Also, url params are not able to be used since the url gets cleared.