### PR TITLE
Handle user authentication state

### DIFF
--- a/src/cosmicds/components/location_helper/LocationHelper.vue
+++ b/src/cosmicds/components/location_helper/LocationHelper.vue
@@ -1,0 +1,12 @@
+<script>
+export default {
+  name: "LocationHelper",
+  created() {
+    window.location.href = this.url;
+  },
+}
+</script>
+
+<template>
+
+</template>

--- a/src/cosmicds/components/location_helper/location_helper.py
+++ b/src/cosmicds/components/location_helper/location_helper.py
@@ -1,0 +1,14 @@
+import solara
+
+
+@solara.component_vue("LocationHelper.vue")
+def LocationHelper(url: str):
+    """
+    Forcibly sets the window location to the given url on instantiation.
+
+    Parameters
+    ----------
+    url : str
+        The absolute url to which the window location should be set.
+    """
+    pass

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -19,6 +19,7 @@ from cosmicds.components.tooltip_menu import TooltipMenu
 from cosmicds.logger import setup_logger
 from cosmicds.utils import get_session_id
 from .components.breakpoint_watcher.breakpoint_watcher import BreakpointWatcher
+from .components.location_helper.location_helper import LocationHelper
 from .components.theme_toggle import ThemeToggle
 from .remote import BASE_API
 from .state import GLOBAL_STATE, BaseLocalState
@@ -87,6 +88,7 @@ def BaseSetup(
 
     def _get_user_info():
         if bool(auth.user.value):
+            logger.debug("User is authenticated.")
             if BASE_API.user_exists:
                 BASE_API.load_user_info(story_name, GLOBAL_STATE)
             elif bool(class_code.value):
@@ -94,14 +96,23 @@ def BaseSetup(
             else:
                 logger.error("User is authenticated, but does not exist.")
                 router.push(auth.get_logout_url())
-                location = solara.use_context(solara.routing._location_context)
-                location.pathname = auth.get_logout_url()
-        else:
-            logger.info("User has not authenticated.")
+        elif not bool(auth.user.value):
+            logger.debug("User has not authenticated.")
             BASE_API.clear_user(GLOBAL_STATE)
-
-            login_dialog = Login(active, class_code, update_db, debug_mode)
-            active.set(True)
+            origin_split = settings.main.base_url.split("//")
+            root_url = "//".join(
+                [
+                    origin_split[0],
+                    "/".join(
+                        [
+                            x
+                            for x in origin_split[1].split("/")
+                            if x not in router.root_path.split("/")
+                        ]
+                    ),
+                ]
+            )
+            LocationHelper(url=root_url)
 
     solara.use_memo(_get_user_info, dependencies=[auth.user.value])
 

--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -86,35 +86,32 @@ def BaseSetup(
         )
         class_code.set("215")
 
-    def _get_user_info():
-        if bool(auth.user.value):
-            logger.debug("User is authenticated.")
-            if BASE_API.user_exists:
-                BASE_API.load_user_info(story_name, GLOBAL_STATE)
-            elif bool(class_code.value):
-                BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
-            else:
-                logger.error("User is authenticated, but does not exist.")
-                router.push(auth.get_logout_url())
-        elif not bool(auth.user.value):
-            logger.debug("User has not authenticated.")
-            BASE_API.clear_user(GLOBAL_STATE)
-            origin_split = settings.main.base_url.split("//")
-            root_url = "//".join(
-                [
-                    origin_split[0],
-                    "/".join(
-                        [
-                            x
-                            for x in origin_split[1].split("/")
-                            if x not in router.root_path.split("/")
-                        ]
-                    ),
-                ]
-            )
-            LocationHelper(url=root_url)
-
-    solara.use_memo(_get_user_info, dependencies=[auth.user.value])
+    if bool(auth.user.value):
+        logger.debug("User is authenticated.")
+        if BASE_API.user_exists:
+            BASE_API.load_user_info(story_name, GLOBAL_STATE)
+        elif bool(class_code.value):
+            BASE_API.create_new_user(story_name, class_code.value, GLOBAL_STATE)
+        else:
+            logger.error("User is authenticated, but does not exist.")
+            router.push(auth.get_logout_url())
+    elif not bool(auth.user.value):
+        logger.debug("User has not authenticated.")
+        BASE_API.clear_user(GLOBAL_STATE)
+        origin_split = settings.main.base_url.split("//")
+        root_url = "//".join(
+            [
+                origin_split[0],
+                "/".join(
+                    [
+                        x
+                        for x in origin_split[1].split("/")
+                        if x not in router.root_path.split("/")
+                    ]
+                ),
+            ]
+        )
+        LocationHelper(url=root_url)
 
 
 def BaseLayout(


### PR DESCRIPTION
This PR adds in functionality to attempt resolving user authentication state, and on failure, force the user back to the portal app. Note that this will not quite work when running locally, since it's not possible to parse the portal url from a story app due to the differing ports (it should route you back to the server base url). On the deployed server, however, this should take the user back to the portal.

Also of note is that the auth reactive variable is unique to each server, so it is not really possible to determine when a user logs out from a different location unless they refresh the entire page. However, this may be different on the deployed server in which the url root is the same. Therefore, I'd like to check this after deploying, and if it's not the case that the auth state is propagated along url root paths, then we'll have to think of a solution to checking the auth state in the stories themselves.