### PR TITLE
use refs in layout

### DIFF
--- a/src/cosmicds/layout.py
+++ b/src/cosmicds/layout.py
@@ -71,9 +71,9 @@ def BaseSetup(
         if BASE_API.is_educator:
             force_demo = True
             educator_mode = True
-            GLOBAL_STATE.value.update_db = False
-            GLOBAL_STATE.value.show_team_interface = True
-            GLOBAL_STATE.value.educator = True
+            Ref(GLOBAL_STATE.fields.update_db).set(False)
+            Ref(GLOBAL_STATE.fields.show_team_interface).set(True)
+            Ref(GLOBAL_STATE.fields.educator).set(True)
 
     if force_demo:
         logger.info("Loading app in demo mode.")


### PR DESCRIPTION
This is meant to fix https://github.com/cosmicds/hubbleds/issues/990.

Looking at this with @johnarban, it seems like the issue was not setting global state variables via a ref. With this update, the issue of educator mode appearing for students goes away.