### PR TITLE
use @Carifio24 dot plot size fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     echo
     glue-core
     glue-jupyter
-    glue-plotly[jupyter]>=0.7.4
+    glue-plotly @ git+https://github.com/Carifio24/glue-plotly.git@dot-size-update
     httpx
     ipyvuetify
     numpy<2.0.0


### PR DESCRIPTION
This is a temporary fix for https://github.com/cosmicds/hubbleds/issues/942. (We will update this properly once Jon's [PR](https://github.com/glue-viz/glue-plotly/pull/124) gets merged in the glue-plotly repo).