### PR TITLE
Make viewer layout card have 100% width

### DIFF
--- a/src/cosmicds/components/viewer_layout.py
+++ b/src/cosmicds/components/viewer_layout.py
@@ -44,6 +44,7 @@ def ViewerLayout(viewer, viewer_height=DEFAULT_VIEWER_HEIGHT):
         classes=["elevation-2 mb-4"],
     )
     with rv.Card(
-        children=[layout]
+        children=[layout],
+        width="100%",
     ):
         pass


### PR DESCRIPTION
This PR updates the width of the `ViewerLayout` card to be 100%. This fixes https://github.com/cosmicds/hubbleds/issues/998.